### PR TITLE
Remove workaround options in order to utilize NDK-based Android DB

### DIFF
--- a/dist/CordovaNativeSqliteProvider.js
+++ b/dist/CordovaNativeSqliteProvider.js
@@ -30,9 +30,7 @@ var CordovaNativeSqliteProvider = (function (_super) {
         }
         this._db = this._plugin.openDatabase({
             name: dbName + '.db',
-            location: 2,
-            androidDatabaseImplementation: 2,
-            androidLockWorkaround: 1
+            location: 2
         });
         if (!this._db) {
             return SyncTasks.Rejected('Couldn\'t open database: ' + dbName);

--- a/src/CordovaNativeSqliteProvider.ts
+++ b/src/CordovaNativeSqliteProvider.ts
@@ -31,9 +31,7 @@ export class CordovaNativeSqliteProvider extends SqlProviderBase.SqlProviderBase
 
         this._db = this._plugin.openDatabase({
             name: dbName + '.db',
-            location: 2,
-            androidDatabaseImplementation: 2,
-            androidLockWorkaround: 1
+            location: 2
         });
 
         if (!this._db) {


### PR DESCRIPTION
Based on commentary in https://github.com/andpor/react-native-sqlite-storage, it appears that the "old" pure Java version of the DB implementation will be obsoleted in the near future, and possibly removed. It seems like we should be using the NDK-based implementation going forward.

Indications are that there is a slight, but minimal, performance gain (https://github.com/andpor/react-native-sqlite-storage/issues/8) using this approach, but more importantly it seems like the "right" way going forward. Should consumers want to explicitly use the old implementation we could expose via a parameter to `open()`.