### PR TITLE
Added getCompletionPromise and abort to all transactions, so you can …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosqlprovider",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A cross-browser/platform indexeddb-like client library",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/CordovaNativeSqliteProvider.ts
+++ b/src/CordovaNativeSqliteProvider.ts
@@ -14,7 +14,7 @@ import SyncTasks = require('synctasks');
 import NoSqlProvider = require('./NoSqlProvider');
 import NoSqlProviderUtils = require('./NoSqlProviderUtils');
 import SqlProviderBase = require('./SqlProviderBase');
-import TransactionLockHelper from './TransactionLockHelper';
+import TransactionLockHelper, { TransactionToken } from './TransactionLockHelper';
 
 export interface SqlitePluginDbOptionalParams {
     createFromLocation?: number;
@@ -57,7 +57,7 @@ export class CordovaNativeSqliteProvider extends SqlProviderBase.SqlProviderBase
 
     open(dbName: string, schema: NoSqlProvider.DbSchema, wipeIfExists: boolean, verbose: boolean): SyncTasks.Promise<void> {
         super.open(dbName, schema, wipeIfExists, verbose);
-        this._lockHelper = new TransactionLockHelper(schema);
+        this._lockHelper = new TransactionLockHelper(schema, true);
 
         if (!this._plugin || !this._plugin.openDatabase) {
             return SyncTasks.Rejected<void>('No support for native sqlite in this browser');
@@ -87,20 +87,16 @@ export class CordovaNativeSqliteProvider extends SqlProviderBase.SqlProviderBase
     }
 
     close(): SyncTasks.Promise<void> {
-        this._closingDefer = SyncTasks.Defer<void>();
-        this._checkClose();
-        return this._closingDefer.promise();
-    }
-
-    private _checkClose() {
-        if (this._closingDefer && this._lockHelper.hasTransaction()) {
+        return this._lockHelper.closeWhenPossible().then(() => {
+            let def = SyncTasks.Defer<void>();
             this._db.close(() => {
                 this._db = null;
-                this._closingDefer.resolve();
-            }, (err) => {
-                this._closingDefer.reject(err);
+                def.resolve();
+            }, err => {
+                def.reject(err);
             });
-        }
+            return def.promise();
+        });
     }
 
     openTransaction(storeNames: string | string[], writeNeeded: boolean): SyncTasks.Promise<SqlProviderBase.SqlTransaction> {
@@ -109,26 +105,25 @@ export class CordovaNativeSqliteProvider extends SqlProviderBase.SqlProviderBase
             return SyncTasks.Rejected('Currently closing provider -- rejecting transaction open');
         }
 
-        return this._lockHelper.checkOpenTransaction(storeNamesArr, writeNeeded).then(() => {
+        return this._lockHelper.openTransaction(storeNamesArr, writeNeeded).then(transToken => {
             const deferred = SyncTasks.Defer<SqlProviderBase.SqlTransaction>();
 
             let ourTrans: SqlProviderBase.SqliteSqlTransaction;
             (writeNeeded ? this._db.transaction : this._db.readTransaction).call(this._db, (trans: SQLTransaction) => {
-                ourTrans = new CordovaNativeSqliteTransaction(trans, this._lockHelper, this._schema, storeNamesArr, writeNeeded,
-                    this._verbose, 999, this._supportsFTS3);
+                ourTrans = new CordovaNativeSqliteTransaction(trans, this._lockHelper, transToken, this._schema, this._verbose, 999,
+                    this._supportsFTS3);
                 deferred.resolve(ourTrans);
-            }, (err) => {
+            }, (err: SQLError) => {
                 if (ourTrans) {
                     ourTrans.internal_markTransactionClosed();
+                    this._lockHelper.transactionFailed(transToken, 'CordovaNativeSqliteTransaction Error: ' + err.message);
                 } else {
-                    // we need to reject transaction only in cases when it's not resolved
+                    // We need to reject the transaction directly only in cases when it never finished creating.
                     deferred.reject(err);
                 }
-                
-                this._checkClose();
             }, () => {
                 ourTrans.internal_markTransactionClosed();
-                this._checkClose();
+                this._lockHelper.transactionComplete(transToken);
             });
             return deferred.promise();
         });    
@@ -138,18 +133,21 @@ export class CordovaNativeSqliteProvider extends SqlProviderBase.SqlProviderBase
 class CordovaNativeSqliteTransaction extends SqlProviderBase.SqliteSqlTransaction {
     constructor(protected trans: SQLTransaction,
                 protected _lockHelper: TransactionLockHelper,
+                protected _transToken: TransactionToken,
                 schema: NoSqlProvider.DbSchema,
-                private _stores: string[],
-                private _exclusive: boolean,
                 verbose: boolean,
                 maxVariables: number,
                 supportsFTS3: boolean) {
         super(trans, schema, verbose, maxVariables, supportsFTS3);
     }
 
-    internal_markTransactionClosed(): void {
-        super.internal_markTransactionClosed();
-        this._lockHelper.transactionComplete(this._stores, this._exclusive);
+    getCompletionPromise(): SyncTasks.Promise<void> {
+        return this._transToken.completionPromise;
+    }
+    
+    abort(): void {
+        this.runQuery('ROLLBACK TRANSACTION');
+        this._lockHelper.transactionFailed(this._transToken, 'CordovaNativeSqliteTransaction Aborted');
     }
 
     protected _requiresUnicodeReplacement(): boolean {

--- a/src/CordovaNativeSqliteProvider.ts
+++ b/src/CordovaNativeSqliteProvider.ts
@@ -43,7 +43,7 @@ export interface SqlitePlugin {
 }
 
 export interface CordovaTransaction extends SQLTransaction {
-    abort(): void;
+    abort(err?: any): void;
 }
 
 export class CordovaNativeSqliteProvider extends SqlProviderBase.SqlProviderBase {
@@ -148,7 +148,7 @@ class CordovaNativeSqliteTransaction extends SqlProviderBase.SqliteSqlTransactio
     }
     
     abort(): void {
-        (this._trans as CordovaTransaction).abort();
+        (this._trans as CordovaTransaction).abort('Manually Aborted');
         this._lockHelper.transactionFailed(this._transToken, 'CordovaNativeSqliteTransaction Aborted');
     }
 

--- a/src/CordovaNativeSqliteProvider.ts
+++ b/src/CordovaNativeSqliteProvider.ts
@@ -148,8 +148,8 @@ class CordovaNativeSqliteTransaction extends SqlProviderBase.SqliteSqlTransactio
     }
     
     abort(): void {
+        // This will wrap through to the transaction error path above.
         (this._trans as CordovaTransaction).abort('Manually Aborted');
-        this._lockHelper.transactionFailed(this._transToken, 'CordovaNativeSqliteTransaction Aborted');
     }
 
     protected _requiresUnicodeReplacement(): boolean {

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -34,9 +34,8 @@ export class InMemoryProvider extends NoSqlProvider.DbProvider {
         return SyncTasks.Resolved<void>();
     }
 
-    openTransaction(storeNames: string | string[], writeNeeded: boolean): SyncTasks.Promise<NoSqlProvider.DbTransaction> {
-        const intStoreNames = NoSqlProviderUtils.arrayify(storeNames);
-        return this._lockHelper.openTransaction(intStoreNames, writeNeeded).then(token =>
+    openTransaction(storeNames: string[], writeNeeded: boolean): SyncTasks.Promise<NoSqlProvider.DbTransaction> {
+        return this._lockHelper.openTransaction(storeNames, writeNeeded).then(token =>
             new InMemoryTransaction(this, this._lockHelper, token));
     }
 

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -73,6 +73,11 @@ export interface DbStore {
 // shortcut accessor functions that get a transaction for you for the one-off queries.
 export interface DbTransaction {
     getStore(storeName: string): DbStore;
+    // This promise will resolve when the transaction commits, or will reject when there's a transaction-level error.
+    getCompletionPromise(): SyncTasks.Promise<void>;
+    // Attempt to abort the transaction (if it hasn't yet completed or aborted).  Completion will be detectable via the
+    // getCompletionPromise promise.
+    abort(): void;
 }
 
 // Abstract base type for a database provider.  Has accessors for opening transactions and one-off accesor helpers.

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -98,7 +98,7 @@ export abstract class DbProvider {
     // You must perform all of your actions on the transaction handed to you in the callback block without letting it expire.
     // When the last callback from the last executed action against the DbTransaction is executed, the transaction closes, so be very
     // careful using deferrals/promises that may wait for the main thread to close out before handling your response.
-    abstract openTransaction(storeNames: string | string[], writeNeeded: boolean): SyncTasks.Promise<DbTransaction>;
+    abstract openTransaction(storeNames: string[], writeNeeded: boolean): SyncTasks.Promise<DbTransaction>;
 
     clearAllData(): SyncTasks.Promise<void> {
         var storeNames = this._schema.stores.map(store => store.name);
@@ -116,7 +116,7 @@ export abstract class DbProvider {
     }
 
     private _getStoreTransaction(storeName: string, readWrite: boolean): SyncTasks.Promise<DbStore> {
-        return this.openTransaction(storeName, readWrite).then(trans => {
+        return this.openTransaction([storeName], readWrite).then(trans => {
             const store = trans.getStore(storeName);
             if (!store) {
                 return SyncTasks.Rejected('Store "' + storeName + '" not found');

--- a/src/NoSqlProviderUtils.ts
+++ b/src/NoSqlProviderUtils.ts
@@ -24,8 +24,8 @@ const keypathJoinerString = '%&';
 // for compound (or non-compound) values.
 export function getSerializedKeyForKeypath(obj: any, keyPathRaw: string | string[]): string {
     const values = getKeyForKeypath(obj, keyPathRaw);
-    if (values === null) {
-        return null;
+    if (values === undefined) {
+        return undefined;
     }
 
     return serializeKeyToString(values, keyPathRaw);
@@ -36,8 +36,8 @@ export function getKeyForKeypath(obj: any, keyPathRaw: string | string[]): any {
 
     const values = _.map(keyPathArray, kp => getValueForSingleKeypath(obj, kp));
     if (_.some(values, val => _.isNull(val) || _.isUndefined(val))) {
-        // If any components of the key are null, then the result is null
-        return null;
+        // If any components of the key are null/undefined, then the result is undefined
+        return undefined;
     }
 
     if (!_.isArray(keyPathRaw)) {
@@ -49,7 +49,7 @@ export function getKeyForKeypath(obj: any, keyPathRaw: string | string[]): any {
 
 // Internal helper function for getting a value out of a standard keypath.
 export function getValueForSingleKeypath(obj: any, keyPath: string): any {
-    return _.get<any>(obj, keyPath, null);
+    return _.get<any>(obj, keyPath, undefined);
 }
 
 export function isCompoundKeyPath(keyPath: string | string[]) {

--- a/src/NoSqlProviderUtils.ts
+++ b/src/NoSqlProviderUtils.ts
@@ -59,7 +59,8 @@ export function isCompoundKeyPath(keyPath: string | string[]) {
 export function formListOfKeys(keyOrKeys: any | any[], keyPath: string | string[]): any[] {
     if (isCompoundKeyPath(keyPath)) {
         if (!isArray(keyOrKeys)) {
-            throw new Error('Compound keypath requires compound keys');
+            throw new Error('formListOfKeys called with a compound keypath (' + JSON.stringify(keyPath) +
+                ') but a non-compound keyOrKeys (' + JSON.stringify(keyOrKeys) + ')');
         }
         if (!isArray(keyOrKeys[0])) {
             // Looks like a single compound key, so make it a list of a single key
@@ -130,11 +131,13 @@ export function serializeKeyToString(key: any | any[], keyPath: string | string[
         if (isArray(key)) {
             return _.map(key, k => serializeValueToOrderableString(k)).join(keypathJoinerString);
         } else {
-            throw new Error('Compound keypath requires compound key');
+            throw new Error('serializeKeyToString called with a compound keypath (' + JSON.stringify(keyPath) +
+                ') but a non-compound key (' + JSON.stringify(key) + ')');
         }
     } else {
         if (isArray(key)) {
-            throw new Error('Non-compound keypath requires non-compound key');
+            throw new Error('serializeKeyToString called with a non-compound keypath (' + JSON.stringify(keyPath) +
+                ') but a compound key (' + JSON.stringify(key) + ')');
         } else {
             return serializeValueToOrderableString(key);
         }

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -83,7 +83,7 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                     });
                 } else if (wipeIfExists) {
                     // No version change, but wipe anyway
-                    return this.openTransaction(undefined, true).then((trans: SqlTransaction) => {
+                    return this.openTransaction('metadata', true).then((trans: SqlTransaction) => {
                         return this._upgradeDb(trans, oldVersion, true);
                     });
                 }
@@ -337,6 +337,9 @@ export abstract class SqlTransaction implements NoSqlProvider.DbTransaction {
         this._isOpen = false;
     }
 
+    abstract getCompletionPromise(): SyncTasks.Promise<void>;
+    abstract abort(): void;
+
     abstract runQuery(sql: string, parameters?: any[]): SyncTasks.Promise<any[]>;
 
     abstract internal_getResultsFromQueryWithCallback(sql: string, parameters: any[], callback: (obj: any) => void): SyncTasks.Promise<void>;
@@ -384,7 +387,7 @@ export abstract class SqlTransaction implements NoSqlProvider.DbTransaction {
 
 // Generic base transaction for anything that matches the syntax of a SQLTransaction interface for executing sql commands.
 // Conveniently, this works for both WebSql and cordova's Sqlite plugin.
-export class SqliteSqlTransaction extends SqlTransaction {
+export abstract class SqliteSqlTransaction extends SqlTransaction {
     private _pendingQueries: SyncTasks.Deferred<any>[] = [];
 
     constructor(protected _trans: SQLTransaction, schema: NoSqlProvider.DbSchema, verbose: boolean, maxVariables: number,
@@ -496,12 +499,25 @@ class SqlStore implements NoSqlProvider.DbStore {
     }
 
     get<T>(key: any | any[]): SyncTasks.Promise<T> {
-        let joinedKey = NoSqlProviderUtils.serializeKeyToString(key, this._schema.primaryKeyPath);
+        let joinedKey: string;
+        const err = _.attempt(() => {
+            joinedKey = NoSqlProviderUtils.serializeKeyToString(key, this._schema.primaryKeyPath);
+        });
+        if (err) {
+            return SyncTasks.Rejected(err);
+        }
+
         return this._trans.internal_getResultFromQuery<T>('SELECT nsp_data FROM ' + this._schema.name + ' WHERE nsp_pk = ?', [joinedKey]);
     }
 
     getMultiple<T>(keyOrKeys: any | any[]): SyncTasks.Promise<T[]> {
-        let joinedKeys = NoSqlProviderUtils.formListOfSerializedKeys(keyOrKeys, this._schema.primaryKeyPath);
+        let joinedKeys: string[];
+        const err = _.attempt(() => {
+            joinedKeys = NoSqlProviderUtils.formListOfSerializedKeys(keyOrKeys, this._schema.primaryKeyPath);
+        });
+        if (err) {
+            return SyncTasks.Rejected(err);
+        }
 
         if (joinedKeys.length === 0) {
             return SyncTasks.Resolved<T[]>([]);
@@ -537,24 +553,29 @@ class SqlStore implements NoSqlProvider.DbStore {
         });
 
         const qmarkString = qmarks.join(',');
-        _.each(<any[]>items, (item) => {
-            let serializedData = JSON.stringify(item);
-            // For now, until an issue with cordova-ios is fixed (https://issues.apache.org/jira/browse/CB-9435), have to replace
-            // \u2028 and 2029 with blanks because otherwise the command boundary with cordova-ios silently eats any strings with them.
-            if (this._replaceUnicode) {
-                serializedData = serializedData.replace(SqlStore._unicodeFixer, '');
-            }
-            args.push(NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._schema.primaryKeyPath), serializedData);
-
-            _.each(this._schema.indexes, index => {
-                if (index.fullText && !this._supportsFTS3) {
-                    args.push(FakeFTSJoinToken +
-                        FullTextSearchHelpers.getFullTextIndexWordsForItem(<string> index.keyPath, item).join(FakeFTSJoinToken));
-                } else if (!index.multiEntry) {
-                    args.push(NoSqlProviderUtils.getSerializedKeyForKeypath(item, index.keyPath));
+        const err = _.attempt(() => {
+            _.each(<any[]>items, (item) => {
+                let serializedData = JSON.stringify(item);
+                // For now, until an issue with cordova-ios is fixed (https://issues.apache.org/jira/browse/CB-9435), have to replace
+                // \u2028 and 2029 with blanks because otherwise the command boundary with cordova-ios silently eats any strings with them.
+                if (this._replaceUnicode) {
+                    serializedData = serializedData.replace(SqlStore._unicodeFixer, '');
                 }
+                args.push(NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._schema.primaryKeyPath), serializedData);
+
+                _.each(this._schema.indexes, index => {
+                    if (index.fullText && !this._supportsFTS3) {
+                        args.push(FakeFTSJoinToken +
+                            FullTextSearchHelpers.getFullTextIndexWordsForItem(<string> index.keyPath, item).join(FakeFTSJoinToken));
+                    } else if (!index.multiEntry) {
+                        args.push(NoSqlProviderUtils.getSerializedKeyForKeypath(item, index.keyPath));
+                    }
+                });
             });
         });
+        if (err) {
+            return SyncTasks.Rejected<void>(err);
+        }
 
         // Need to not use too many variables per insert, so batch the insert if needed.
         let inserts: SyncTasks.Promise<void>[] = [];
@@ -572,45 +593,57 @@ class SqlStore implements NoSqlProvider.DbStore {
 
                 // Go through and do followup inserts for multientry indexes
                 _.each(items, item => {
-                    queries.push(this._trans.runQuery('SELECT rowid a FROM ' + this._schema.name + ' WHERE nsp_pk = ?',
-                        [NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._schema.primaryKeyPath)])
-                        .then(rets => {
-                            let rowid = rets[0].a;
+                    let key: string;
+                    const err = _.attempt(() => {
+                        key = NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._schema.primaryKeyPath);
+                    });
+                    if (err) {
+                        queries.push(SyncTasks.Rejected<void>(err));
+                    }
 
-                            let inserts: SyncTasks.Promise<void>[] = [];
-                            _.each(this._schema.indexes, index => {
-                                let serializedKeys: string[];
+                    queries.push(this._trans.runQuery('SELECT rowid a FROM ' + this._schema.name + ' WHERE nsp_pk = ?', [key]).then(rets => {
+                        let rowid = rets[0].a;
 
-                                if (index.fullText && this._supportsFTS3) {
-                                    // FTS3 terms go in a separate virtual table...
-                                    serializedKeys = [FullTextSearchHelpers.getFullTextIndexWordsForItem(<string> index.keyPath, item).join(' ')];
-                                } else if (index.multiEntry) {
-                                    // Have to extract the multiple entries into the alternate table...
-                                    const valsRaw = NoSqlProviderUtils.getValueForSingleKeypath(item, <string>index.keyPath);
-                                    if (valsRaw) {
+                        let inserts: SyncTasks.Promise<void>[] = [];
+                        _.each(this._schema.indexes, index => {
+                            let serializedKeys: string[];
+
+                            if (index.fullText && this._supportsFTS3) {
+                                // FTS3 terms go in a separate virtual table...
+                                serializedKeys = [FullTextSearchHelpers.getFullTextIndexWordsForItem(<string> index.keyPath, item).join(' ')];
+                            } else if (index.multiEntry) {
+                                // Have to extract the multiple entries into the alternate table...
+                                const valsRaw = NoSqlProviderUtils.getValueForSingleKeypath(item, <string>index.keyPath);
+                                if (valsRaw) {
+                                    const err = _.attempt(() => {
                                         serializedKeys = _.map(NoSqlProviderUtils.arrayify(valsRaw), val =>
                                             NoSqlProviderUtils.serializeKeyToString(val, <string>index.keyPath));
+                                    });
+                                    if (err) {
+                                        inserts.push(SyncTasks.Rejected<void>(err));
+                                        return;
                                     }
-                                } else {
-                                    return;
                                 }
+                            } else {
+                                return;
+                            }
 
-                                let valArgs = [], args = [];
-                                _.each(serializedKeys, val => {
-                                    valArgs.push('(?, ?)');
-                                    args.push(val);
-                                    args.push(rowid);
-                                });
-                                inserts.push(this._trans.internal_nonQuery('DELETE FROM ' + this._schema.name + '_' + index.name +
-                                        ' WHERE nsp_refrowid = ?', [rowid]).then(() => {
-                                    if (valArgs.length > 0){
-                                        return this._trans.internal_nonQuery('INSERT INTO ' + this._schema.name + '_' + index.name +
-                                            ' (nsp_key, nsp_refrowid) VALUES ' + valArgs.join(','), args);
-                                    }
-                                }));
+                            let valArgs = [], args = [];
+                            _.each(serializedKeys, val => {
+                                valArgs.push('(?, ?)');
+                                args.push(val);
+                                args.push(rowid);
                             });
-                            return SyncTasks.all(inserts).then(_.noop);
-                        }));
+                            inserts.push(this._trans.internal_nonQuery('DELETE FROM ' + this._schema.name + '_' + index.name +
+                                    ' WHERE nsp_refrowid = ?', [rowid]).then(() => {
+                                if (valArgs.length > 0){
+                                    return this._trans.internal_nonQuery('INSERT INTO ' + this._schema.name + '_' + index.name +
+                                        ' (nsp_key, nsp_refrowid) VALUES ' + valArgs.join(','), args);
+                                }
+                            }));
+                        });
+                        return SyncTasks.all(inserts).then(_.noop);
+                    }));
                 });
 
                 return SyncTasks.all(queries).then(_.noop);
@@ -619,7 +652,13 @@ class SqlStore implements NoSqlProvider.DbStore {
     }
 
     remove(keyOrKeys: any | any[]): SyncTasks.Promise<void> {
-        let joinedKeys = NoSqlProviderUtils.formListOfSerializedKeys(keyOrKeys, this._schema.primaryKeyPath);
+        let joinedKeys: string[];
+        const err = _.attempt(() => {
+            joinedKeys = NoSqlProviderUtils.formListOfSerializedKeys(keyOrKeys, this._schema.primaryKeyPath);
+        });
+        if (err) {
+            return SyncTasks.Rejected<void>(err);
+        }
 
         // PERF: This is optimizable, but it's of questionable utility
         var queries = _.map(joinedKeys, joinedKey => {
@@ -720,19 +759,35 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
     }
 
     getOnly<T>(key: any | any[], reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<T[]> {
-        let joinedKey = NoSqlProviderUtils.serializeKeyToString(key, this._keyPath);
+        let joinedKey: string;
+        const err = _.attempt(() => {
+            joinedKey = NoSqlProviderUtils.serializeKeyToString(key, this._keyPath);
+        });
+        if (err) {
+            return SyncTasks.Rejected(err);
+        }
 
         return this._handleQuery<T>('SELECT nsp_data FROM ' + this._tableName + ' WHERE ' + this._queryColumn + ' = ?', [joinedKey],
             reverse, limit, offset);
     }
 
     getRange<T>(keyLowRange: any | any[], keyHighRange: any | any[], lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
-        reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<T[]> {
-        const { checks, args } = this._getRangeChecks(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
-        return this._handleQuery<T>('SELECT nsp_data FROM ' + this._tableName + ' WHERE ' + checks.join(' AND '), args, reverse, limit,
-            offset);
+            reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<T[]> {
+        let checks: string;
+        let args: string[];
+        const err = _.attempt(() => {
+            const ret = this._getRangeChecks(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
+            checks = ret.checks;
+            args = ret.args;
+        });
+        if (err) {
+            return SyncTasks.Rejected(err);
+        }
+        
+        return this._handleQuery<T>('SELECT nsp_data FROM ' + this._tableName + ' WHERE ' + checks, args, reverse, limit, offset);
     }
 
+    // Warning: This function can throw, make sure to trap.
     private _getRangeChecks(keyLowRange: any | any[], keyHighRange: any | any[], lowRangeExclusive?: boolean, highRangeExclusive?: boolean) {
         let checks: string[] = [];
         let args: string[] = [];
@@ -744,7 +799,7 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
             checks.push(this._queryColumn + (highRangeExclusive ? ' < ' : ' <= ') + '?');
             args.push(NoSqlProviderUtils.serializeKeyToString(keyHighRange, this._keyPath));
         }
-        return { checks, args };
+        return { checks: checks.join(' AND '), args };
     }
 
     countAll(): SyncTasks.Promise<number> {
@@ -752,7 +807,13 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
     }
 
     countOnly(key: any|any[]): SyncTasks.Promise<number> {
-        let joinedKey = NoSqlProviderUtils.serializeKeyToString(key, this._keyPath);
+        let joinedKey: string;
+        const err = _.attempt(() => {
+            joinedKey = NoSqlProviderUtils.serializeKeyToString(key, this._keyPath);
+        });
+        if (err) {
+            return SyncTasks.Rejected(err);
+        }
 
         return this._trans.runQuery('SELECT COUNT(*) cnt FROM ' + this._tableName + ' WHERE ' + this._queryColumn
             + ' = ?', [joinedKey]).then(result => result[0]['cnt']);
@@ -760,9 +821,19 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
 
     countRange(keyLowRange: any|any[], keyHighRange: any|any[], lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
             : SyncTasks.Promise<number> {
-        const { checks, args } = this._getRangeChecks(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
-        return this._trans.runQuery('SELECT COUNT(*) cnt FROM ' + this._tableName + ' WHERE ' + checks.join(' AND '),
-            args).then(result => result[0]['cnt']);
+        let checks: string;
+        let args: string[];
+        const err = _.attempt(() => {
+            const ret = this._getRangeChecks(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
+            checks = ret.checks;
+            args = ret.args;
+        });
+        if (err) {
+            return SyncTasks.Rejected(err);
+        }
+
+        return this._trans.runQuery('SELECT COUNT(*) cnt FROM ' + this._tableName + ' WHERE ' + checks, args)
+            .then(result => result[0]['cnt']);
     }
 
     fullTextSearch<T>(searchPhrase: string, resolution: NoSqlProvider.FullTextTermResolution = NoSqlProvider.FullTextTermResolution.And)

--- a/src/TransactionLockHelper.ts
+++ b/src/TransactionLockHelper.ts
@@ -16,50 +16,105 @@ import NoSqlProvider = require('./NoSqlProvider');
 interface PendingTransaction {
     storeNames: string[];
     exclusive: boolean;
-    defer: SyncTasks.Deferred<void>;
+    openDefer: SyncTasks.Deferred<TransactionToken>;
+}
+
+export interface TransactionToken {
+    completionPromise: SyncTasks.Promise<void>;
+    storeNames: string[];
+    exclusive: boolean;
+}
+
+interface TransactionTokenInternal extends TransactionToken {
+    completionDefer: SyncTasks.Deferred<void>;
 }
 
 class TransactionLockHelper {
+    private _closingDefer: SyncTasks.Deferred<void>;
+    private _closed = false;
+
     protected _exclusiveLocks: _.Dictionary<boolean> = {};
     protected _readOnlyCounts: _.Dictionary<number> = {};
 
     private _pendingTransactions: PendingTransaction[] = [];
     
-    constructor(schema: NoSqlProvider.DbSchema) {
+    constructor(schema: NoSqlProvider.DbSchema, private _supportsDiscreteTransactions: boolean) {
         _.each(schema.stores, store => {
             this._exclusiveLocks[store.name] = false;
             this._readOnlyCounts[store.name] = 0;
         });
     }
 
+    closeWhenPossible(): SyncTasks.Promise<void> {
+        if (!this._closingDefer) {
+            this._closingDefer = SyncTasks.Defer<void>();
+            this._checkClose();
+        }
+        
+        return this._closingDefer.promise();
+    }
+
+    private _checkClose() {
+        if (!this._closed && this._closingDefer && !this.hasTransaction() ) {
+            this._closed = true;
+            this._closingDefer.resolve();
+        }
+    }
+
     hasTransaction(): boolean {
         return this._pendingTransactions.length > 0 ||
-            _.some(this._exclusiveLocks, (value) =>  value) ||
+            _.some(this._exclusiveLocks, (value) => value) ||
             _.some(this._readOnlyCounts, (value) => value > 0);
     }
 
-    checkOpenTransaction(storeNames: string[], exclusive: boolean): SyncTasks.Promise<void> {
+    openTransaction(storeNames: string[], exclusive: boolean): SyncTasks.Promise<TransactionToken> {
         const pendingTrans: PendingTransaction = {
             storeNames,
             exclusive,
-            defer: SyncTasks.Defer<void>()
+            openDefer: SyncTasks.Defer<TransactionToken>()
         };
 
         this._pendingTransactions.push(pendingTrans);
 
         this._checkNextTransactions();
 
-        return pendingTrans.defer.promise();
+        return pendingTrans.openDefer.promise();
     }
 
-    transactionComplete(storeNames: string[], exclusive: boolean) {
-        if (exclusive) {
-            _.each(storeNames, storeName => {
+    transactionComplete(token: TransactionToken) {
+        const tokenInt = token as TransactionTokenInternal;
+        if (tokenInt.completionDefer) {
+            const toResolve = tokenInt.completionDefer;
+            tokenInt.completionDefer = undefined;
+            toResolve.resolve();
+        } else {
+            throw new Error('Completing a transaction that has already been completed');
+        }
+
+        this._cleanTransaction(token);
+    }
+
+    transactionFailed(token: TransactionToken, message: string) {
+        const tokenInt = token as TransactionTokenInternal;
+        if (tokenInt.completionDefer) {
+            const toResolve = tokenInt.completionDefer;
+            tokenInt.completionDefer = undefined;
+            toResolve.reject(new Error(message));
+        } else {
+            throw new Error('Failing a transaction that has already been completed');
+        }
+
+        this._cleanTransaction(token);
+    }
+
+    private _cleanTransaction(token: TransactionToken) {
+        if (token.exclusive) {
+            _.each(token.storeNames, storeName => {
                 assert.ok(this._exclusiveLocks[storeName], 'Missing expected exclusive lock for store: ' + storeName);
                 this._exclusiveLocks[storeName] = false;
             });
         } else {
-            _.each(storeNames, storeName => {
+            _.each(token.storeNames, storeName => {
                 assert.ok(this._readOnlyCounts[storeName] > 0, 'Missing expected readonly lock for store: ' + storeName);
                 this._readOnlyCounts[storeName]--;
             });
@@ -69,13 +124,18 @@ class TransactionLockHelper {
     }
 
     private _checkNextTransactions(): void {
-        let toResolve: SyncTasks.Deferred<void>[] = [];
-
         for (let i = 0; i < this._pendingTransactions.length; ) {
             const trans = this._pendingTransactions[i];
 
-            if (_.some(trans.storeNames, storeName => this._exclusiveLocks[storeName] ||
-                    (trans.exclusive && this._readOnlyCounts[storeName] > 0))) {
+            if (this._closingDefer) {
+                this._pendingTransactions.splice(i, 1);
+                trans.openDefer.reject('Closing Provider');   
+                continue;             
+            }
+
+            if (trans.exclusive && !this._supportsDiscreteTransactions && _.some(this._exclusiveLocks, lock => lock) ||
+                    _.some(trans.storeNames, storeName => this._exclusiveLocks[storeName] ||
+                        (trans.exclusive && this._readOnlyCounts[storeName] > 0))) {
                 i++;
                 continue;
             }
@@ -92,12 +152,18 @@ class TransactionLockHelper {
                 });
             }
 
-            toResolve.push(trans.defer);
+            const newDefer = SyncTasks.Defer<void>();
+            const newToken: TransactionTokenInternal = {
+                completionDefer: newDefer,
+                completionPromise: newDefer.promise(),
+                exclusive: trans.exclusive,
+                storeNames: trans.storeNames
+            };
+
+            trans.openDefer.resolve(newToken);
         }
 
-        _.each(toResolve, defer => {
-            defer.resolve();
-        });
+        this._checkClose();
     }
 }
 

--- a/src/WebSqlProvider.ts
+++ b/src/WebSqlProvider.ts
@@ -54,7 +54,7 @@ export class WebSqlProvider extends SqlProviderBase.SqlProviderBase {
             }
 
             this._db.changeVersion(this._db.version, this._schema.version.toString(), (t) => {
-                let trans = new SqlProviderBase.SqliteSqlTransaction(t, this._schema, this._verbose, 999, this._supportsFTS3);
+                let trans = new WebSqlTransaction(t, undefined, this._schema, this._verbose, 999, this._supportsFTS3);
 
                 this._upgradeDb(trans, oldVersion, wipeIfExists).then(() => { deferred.resolve(); }, () => { deferred.reject(); });
             }, (err) => {
@@ -82,9 +82,10 @@ export class WebSqlProvider extends SqlProviderBase.SqlProviderBase {
         const deferred = SyncTasks.Defer<SqlProviderBase.SqlTransaction>();
 
         let ourTrans: SqlProviderBase.SqliteSqlTransaction = null;
+        let finishDefer = SyncTasks.Defer<void>();
         (writeNeeded ? this._db.transaction : this._db.readTransaction).call(this._db,
-            trans => {
-                ourTrans = new SqlProviderBase.SqliteSqlTransaction(trans, this._schema, this._verbose, 999, this._supportsFTS3);
+            (trans: SQLTransaction) => {
+                ourTrans = new WebSqlTransaction(trans, finishDefer.promise(), this._schema, this._verbose, 999, this._supportsFTS3);
                 deferred.resolve(ourTrans);
             }, (err) => {
                 if (ourTrans) {
@@ -92,13 +93,42 @@ export class WebSqlProvider extends SqlProviderBase.SqlProviderBase {
                     // transaction since they won't exit out gracefully for whatever reason.
                     ourTrans.failAllPendingQueries(err);
                     ourTrans.internal_markTransactionClosed();
+                    if (finishDefer) {
+                        finishDefer.reject('WebSqlTransaction Error: ' + err.message);
+                        finishDefer = undefined;
+                    }
                 } else {
                     deferred.reject(err);
                 }
             }, () => {
                 ourTrans.internal_markTransactionClosed();
+                if (finishDefer) {
+                    finishDefer.resolve();
+                    finishDefer = undefined;
+                }
             });
 
         return deferred.promise();
+    }
+}
+
+class WebSqlTransaction extends SqlProviderBase.SqliteSqlTransaction {
+    constructor(protected trans: SQLTransaction,
+                private _completionPromise: SyncTasks.Promise<void>, 
+                schema: NoSqlProvider.DbSchema,
+                verbose: boolean,
+                maxVariables: number,
+                supportsFTS3: boolean) {
+        super(trans, schema, verbose, maxVariables, supportsFTS3);
+    }
+
+    getCompletionPromise(): SyncTasks.Promise<void> {
+        return this._completionPromise;
+    }
+    
+    abort(): void {
+        // The only way to rollback a websql transaction is by forcing an error (which rolls back the trans):
+        // http://stackoverflow.com/questions/16225320/websql-dont-rollback
+        this.runQuery('ERROR ME TO DEATH');
     }
 }

--- a/src/WebSqlProvider.ts
+++ b/src/WebSqlProvider.ts
@@ -62,7 +62,7 @@ export class WebSqlProvider extends SqlProviderBase.SqlProviderBase {
             });
         } else if (wipeIfExists) {
             // No version change, but wipe anyway
-            this.openTransaction(null, true).then(trans => {
+            this.openTransaction(undefined, true).then(trans => {
                 this._upgradeDb(trans, oldVersion, true).then(() => { deferred.resolve(); }, () => { deferred.reject(); });
             }, (err) => {
                 deferred.reject(err);
@@ -78,7 +78,7 @@ export class WebSqlProvider extends SqlProviderBase.SqlProviderBase {
         return SyncTasks.Resolved<void>();
     }
 
-    openTransaction(storeNames: string | string[], writeNeeded: boolean): SyncTasks.Promise<SqlProviderBase.SqlTransaction> {
+    openTransaction(storeNames: string[], writeNeeded: boolean): SyncTasks.Promise<SqlProviderBase.SqlTransaction> {
         const deferred = SyncTasks.Defer<SqlProviderBase.SqlTransaction>();
 
         let ourTrans: SqlProviderBase.SqliteSqlTransaction = null;
@@ -129,6 +129,6 @@ class WebSqlTransaction extends SqlProviderBase.SqliteSqlTransaction {
     abort(): void {
         // The only way to rollback a websql transaction is by forcing an error (which rolls back the trans):
         // http://stackoverflow.com/questions/16225320/websql-dont-rollback
-        this.runQuery('ERROR ME TO DEATH');
+        this.runQuery('ERROR ME TO DEATH').catch(() => undefined);
     }
 }

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -338,13 +338,10 @@ describe('NoSqlProvider', function () {
                                 }
                             ]
                         }, true).then(prov => {
-                            const oldCatchMode = SyncTasks.config.catchExceptions;
-                            SyncTasks.config.catchExceptions = true;
                             return prov.put('test', { id: { x: 'a' }, val: 'b' }).then(() => {
                                 assert(false, 'Shouldn\'t get here');
                             }, (err) => {
                                 // Woot, failed like it's supposed to
-                                SyncTasks.config.catchExceptions = oldCatchMode;
                                 return prov.close();
                             });
                         });

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -4,6 +4,7 @@ import SyncTasks = require('synctasks');
 
 import NoSqlProvider = require('../NoSqlProvider');
 
+import { CordovaNativeSqliteProvider } from '../CordovaNativeSqliteProvider';
 import { InMemoryProvider } from '../InMemoryProvider';
 import { IndexedDbProvider } from '../IndexedDbProvider';
 import { WebSqlProvider } from '../WebSqlProvider';
@@ -31,6 +32,9 @@ function openProvider(providerName: string, schema: NoSqlProvider.DbSchema, wipe
         provider = new WebSqlProvider();
     } else if (providerName === 'websqlnofts3') {
         provider = new WebSqlProvider(false);
+    } else if (providerName === 'reactnative') {
+        var reactNativeSqliteProvider = require('react-native-sqlite-storage');
+        provider = new CordovaNativeSqliteProvider(reactNativeSqliteProvider);
     }
     return NoSqlProvider.openListOfProviders([provider], 'test', schema, wipeFirst, false);
 }


### PR DESCRIPTION
…tell when a transaction actually commits or errors/aborts (and abort it if you want).  Added proper transactional semantics to InMemoryProvider and NodeSqlite3Provider to support these.  Plumbed proper exception catching through all the places where we might be throwing from a util, and wrap it to a rejected promise for whatever the intended action was.  Added helpers to TransactionLockHelper for not closing the DB until all the transactions are closed. (helps fix crashes in node sqlite3) Altered TransactionLockHelper to specify whether the underlying store supports discrete transactions or not (node sqlite3 doesn't, since we're manually doing transactions on a single connection.)