### PR TITLE
0.5.8 Update multi-table index to use primary key instead of rowid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosqlprovider",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "A cross-browser/platform indexeddb-like client library",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -440,7 +440,7 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
                                     keys = _.map(keys, val => NoSqlProviderUtils.serializeKeyToString(val, <string>index.keyPath));
                                 }
 
-                                // We need to reference the PK of the actual row we're using here, so calculate the actual PK -- if it's 
+                                // We need to reference the PK of the actual row we're using here, so calculate the actual PK -- if it's
                                 // compound, we're already faking complicated keys, so we know to serialize it to a string.  If not, use the
                                 // raw value.
                                 refKey = NoSqlProviderUtils.getKeyForKeypath(item, this._schema.primaryKeyPath);
@@ -525,7 +525,14 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
 
                             let refKey: string;
                             const err = _.attempt(() => {
-                                refKey = NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._schema.primaryKeyPath);
+
+                                // We need to reference the PK of the actual row we're using here, so calculate the actual PK -- if it's
+                                // compound, we're already faking complicated keys, so we know to serialize it to a string.  If not, use the
+                                // raw value.
+                                refKey = NoSqlProviderUtils.getKeyForKeypath(item, this._schema.primaryKeyPath);
+                                if (_.isArray(this._schema.primaryKeyPath)) {
+                                    refKey = NoSqlProviderUtils.serializeKeyToString(refKey, this._schema.primaryKeyPath);
+                                }
                             });
                             if (err) {
                                 return SyncTasks.Rejected<void>(err);
@@ -639,7 +646,7 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
             reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<T[]> {
         let keyRange: any;
         const err = _.attempt(() => {
-            keyRange = this._getKeyRangeForRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);                
+            keyRange = this._getKeyRangeForRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
         });
         if (err) {
             return SyncTasks.Rejected(err);
@@ -674,7 +681,7 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
         if (err) {
             return SyncTasks.Rejected(err);
         }
-        
+
         const req = this._store.count(keyRange);
         return this._countRequest(req);
     }
@@ -683,7 +690,7 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
             : SyncTasks.Promise<number> {
         let keyRange: any;
         const err = _.attempt(() => {
-            keyRange = this._getKeyRangeForRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);                
+            keyRange = this._getKeyRangeForRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
         });
         if (err) {
             return SyncTasks.Rejected(err);


### PR DESCRIPTION
Turns out rowid gets updated when doing an INSERT OR REPLACE and there's no requirement for it to remain constant forever. This can result in orphaned results and null/undefined values coming out of the DB for multi-key indexes