### PR TITLE
Issue deletes in chunks instead of individually using the DELETE … IN (list_of_ids)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
     "synctasks": "^0.2.12"
   },
   "devDependencies": {
-    "@types/mocha": "^2.2.38",
+    "@types/mocha": "2.2.38",
+    "awesome-typescript-loader": "^3.2.1",
     "mocha": "^2.3.4",
     "sqlite3": "^3.0.9",
-    "ts-loader": "2.0.3",
-    "tslint": "4.5.1",
-    "typescript": "2.4.2",
-    "webpack": "^1.0.0"
+    "tslint": "^5.0.0",
+    "tslint-microsoft-contrib": "^4.0.1",
+    "typescript": "2.6.0-dev.20170826",
+    "webpack": "^3.3.0"
   },
   "repository": {
     "type": "git",

--- a/src/CordovaNativeSqliteProvider.ts
+++ b/src/CordovaNativeSqliteProvider.ts
@@ -38,7 +38,7 @@ export interface SqliteDatabase {
 
 export interface SqlitePlugin {
     openDatabase(dbInfo: SqlitePluginDbParams, success?: Function, error?: Function): SqliteDatabase;
-    deleteDatabase(dbInfo: SqlitePluginDbParams, successCallback?: Function, errorCallback?: Function);
+    deleteDatabase(dbInfo: SqlitePluginDbParams, successCallback?: Function, errorCallback?: Function): void;
     sqliteFeatures: { isSQLitePlugin: boolean };
 }
 
@@ -78,7 +78,7 @@ export class CordovaNativeSqliteProvider extends SqlProviderBase.SqlProviderBase
         const task = SyncTasks.Defer<void>();
         this._db = this._plugin.openDatabase(dbParams, () => {
             task.resolve();
-        }, err => {
+        }, (err: any) => {
             task.reject('Couldn\'t open database: ' + dbName + ', error: ' + JSON.stringify(err));
         });
 
@@ -96,7 +96,7 @@ export class CordovaNativeSqliteProvider extends SqlProviderBase.SqlProviderBase
             this._db.close(() => {
                 this._db = null;
                 def.resolve();
-            }, err => {
+            }, (err: any) => {
                 def.reject(err);
             });
             return def.promise();

--- a/src/FullTextSearchHelpers.ts
+++ b/src/FullTextSearchHelpers.ts
@@ -22,7 +22,6 @@ function sqlCompat(value: string): string {
 }
 
 export function breakAndNormalizeSearchPhrase(phrase: string): string[] {
-
     // Faster than using _.uniq since it's just a pile of strings.
     // Deburr and tolower before using _.words since _.words breaks on CaseChanges.
     return _.map(_.mapKeys(_.words(_.deburr(phrase).toLowerCase(), _whitespaceRegexMatch)), (value, key) => sqlCompat(key));
@@ -37,13 +36,13 @@ export function getFullTextIndexWordsForItem(keyPath: string, item: any): string
 export abstract class DbIndexFTSFromRangeQueries implements NoSqlProvider.DbIndex {
     protected _keyPath: string | string[];
 
-    constructor(protected _indexSchema: NoSqlProvider.IndexSchema, protected _primaryKeyPath: string | string[]) {
+    constructor(protected _indexSchema: NoSqlProvider.IndexSchema|undefined, protected _primaryKeyPath: string | string[]) {
         this._keyPath = this._indexSchema ? this._indexSchema.keyPath : this._primaryKeyPath;
     }
 
     fullTextSearch<T>(searchPhrase: string, resolution: NoSqlProvider.FullTextTermResolution = NoSqlProvider.FullTextTermResolution.And, limit?: number)
             : SyncTasks.Promise<T[]> {
-        if (!this._indexSchema.fullText) {
+        if (!this._indexSchema || !this._indexSchema.fullText) {
             return SyncTasks.Rejected<T[]>('fullTextSearch performed against non-fullText index!');
         }
 
@@ -68,7 +67,7 @@ export abstract class DbIndexFTSFromRangeQueries implements NoSqlProvider.DbInde
             }
 
             if (resolution === NoSqlProvider.FullTextTermResolution.Or) {
-                const data = _.values(_.assign<_.Dictionary<T>>({}, ...uniquers));
+                const data = _.values(_.assign<_.Dictionary<T>>({}, ...uniquers!!!));
                 if (limit) {
                     return _.take(data, limit);
                 }
@@ -76,7 +75,7 @@ export abstract class DbIndexFTSFromRangeQueries implements NoSqlProvider.DbInde
             }
 
             if (resolution === NoSqlProvider.FullTextTermResolution.And) {
-                const [first, ...others] = uniquers;
+                const [first, ...others] = uniquers!!!;
                 const data = _.values(_.pickBy<_.Dictionary<T>, _.Dictionary<T>>(first, (value, key) => _.every(others, set => key in set)));
                 if (limit) {
                     return _.take(data, limit);

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -215,7 +215,7 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
                     const fakeToken: TransactionToken = {
                         storeNames: [ storeSchema.name ],
                         exclusive: false,
-                        completionPromise: undefined
+                        completionPromise: SyncTasks.Defer<void>().promise()
                     };
                     const iTrans = new IndexedDbTransaction(trans, undefined, fakeToken, schema, this._fakeComplicatedKeys);
                     const tStore = iTrans.getStore(storeSchema.name);

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -215,7 +215,7 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
                     const fakeToken: TransactionToken = {
                         storeNames: [ storeSchema.name ],
                         exclusive: false,
-                        completionPromise: SyncTasks.Defer<void>().promise()
+                        completionPromise: undefined
                     };
                     const iTrans = new IndexedDbTransaction(trans, undefined, fakeToken, schema, this._fakeComplicatedKeys);
                     const tStore = iTrans.getStore(storeSchema.name);

--- a/src/NoSqlProviderUtils.ts
+++ b/src/NoSqlProviderUtils.ts
@@ -22,7 +22,7 @@ const keypathJoinerString = '%&';
 
 // This function computes a serialized single string value for a keypath on an object.  This is used for generating ordered string keys
 // for compound (or non-compound) values.
-export function getSerializedKeyForKeypath(obj: any, keyPathRaw: string | string[]): string {
+export function getSerializedKeyForKeypath(obj: any, keyPathRaw: string | string[]): string|undefined {
     const values = getKeyForKeypath(obj, keyPathRaw);
     if (values === undefined) {
         return undefined;
@@ -150,5 +150,5 @@ export function formListOfSerializedKeys(keyOrKeys: any | any[], keyPath: string
 
 export function isIE() {
     return (typeof (document) !== 'undefined' && document.all !== null && document.documentMode <= 11) ||
-        (typeof (navigator) !== 'undefined' && navigator.userAgent && navigator.userAgent.indexOf('Edge/') !== -1);
+        (typeof (navigator) !== 'undefined' && !!navigator.userAgent && navigator.userAgent.indexOf('Edge/') !== -1);
 }

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -696,7 +696,7 @@ class SqlStore implements NoSqlProvider.DbStore {
                     }
 
                     let valArgs: string[] = [], insertArgs: string[] = [];
-                    _.each(serializedKeys!!!, val => {
+                    _.each(serializedKeys, val => {
                         valArgs.push(index.includeDataInIndex ? '(?, ?, ?)' : '(?, ?)');
                         insertArgs.push(val);
                         insertArgs.push(key);

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -756,9 +756,10 @@ class SqlStore implements NoSqlProvider.DbStore {
             // Accumulate the length
             totalLength += joinedKey.length + 2;
 
-            // Make sure we don't exceed the max sql statement limit, if so go to the next partition
+            // Make sure we don't exceed the following sqlite limits, if so go to the next partition
             let didReachSqlStatementLimit = totalLength > (SQLITE_MAX_SQL_LENGTH_IN_BYTES - 200);
-            if (didReachSqlStatementLimit) {
+            let didExceedMaxVariableCount = this._trans.internal_getMaxVariables();
+            if (didReachSqlStatementLimit || didExceedMaxVariableCount) {
                 totalLength = 0;
                 partitionIndex++;
                 arrayOfParams.push(new Array<String>());

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -747,6 +747,7 @@ class SqlStore implements NoSqlProvider.DbStore {
         // Partition the parameters
         var arrayOfParams: Array<Array<String>> = [[]];
         var totalLength = 0;
+        var totalItems = 0;
         var partitionIndex = 0;
         joinedKeys.forEach(joinedKey => {
 
@@ -756,11 +757,14 @@ class SqlStore implements NoSqlProvider.DbStore {
             // Accumulate the length
             totalLength += joinedKey.length + 2;
 
+            totalItems++;
+
             // Make sure we don't exceed the following sqlite limits, if so go to the next partition
             let didReachSqlStatementLimit = totalLength > (SQLITE_MAX_SQL_LENGTH_IN_BYTES - 200);
-            let didExceedMaxVariableCount = this._trans.internal_getMaxVariables();
+            let didExceedMaxVariableCount = totalItems >= this._trans.internal_getMaxVariables();
             if (didReachSqlStatementLimit || didExceedMaxVariableCount) {
                 totalLength = 0;
+                totalItems = 0;
                 partitionIndex++;
                 arrayOfParams.push(new Array<String>());
             }

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -728,7 +728,7 @@ class SqlStore implements NoSqlProvider.DbStore {
     }
 
     remove(keyOrKeys: any | any[]): SyncTasks.Promise<void> {
-        let joinedKeys: string[];
+        let joinedKeys: string[] = [];
         const err = _.attempt(() => {
             joinedKeys = NoSqlProviderUtils.formListOfSerializedKeys(keyOrKeys, this._schema.primaryKeyPath);
         });

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -29,7 +29,7 @@ function getIndexIdentifier(storeSchema: NoSqlProvider.StoreSchema, index: NoSql
 // * Multientry indexes
 // * Full-text indexes that support FTS3
 function indexUsesSeparateTable(indexSchema: NoSqlProvider.IndexSchema, supportsFTS3: boolean): boolean {
-    return indexSchema.multiEntry || (indexSchema.fullText && supportsFTS3);
+    return indexSchema.multiEntry || (!!indexSchema.fullText && supportsFTS3);
 }
 
 const FakeFTSJoinToken = '^$^';
@@ -105,14 +105,14 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
             // Get Index metadatas
             let indexMetadata: IndexMetadata[] = _.chain(fullMeta)
                 .map(meta => {
-                    let metaObj: IndexMetadata;
+                    let metaObj: IndexMetadata|undefined;
                     _.attempt(() => {
                         metaObj = JSON.parse(meta.value);
                     });
                     return metaObj;
                 })
-                .filter(meta => meta && !!meta.storeName)
-                .value();
+                .filter(meta => !!meta && !!meta.storeName)
+                .value() as IndexMetadata[];
             return trans.runQuery('SELECT type, name, tbl_name, sql from sqlite_master', [])
                 .then(rows => {
                     let tableNames: string[] = [];
@@ -315,7 +315,7 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                                 // Nuke old indexes on the original table (since they don't change names and we don't need them anymore).
                                 // Also new old multientry/FTS tables (if they still exist after the purge above.)
                                 let indexDroppers: SyncTasks.Promise<any[]>[] = _.map(indexNames[storeSchema.name], indexName =>
-                                    trans.runQuery('DROP INDEX ' + indexName)).concat(_.map(indexTables[storeSchema.name], tableName => 
+                                    trans.runQuery('DROP INDEX ' + indexName)).concat(_.map(indexTables[storeSchema.name], tableName =>
                                     trans.runQuery('DROP TABLE IF EXISTS ' + storeSchema.name + '_' + tableName)));
 
                                 let nukeIndexesAndRename = SyncTasks.all(indexDroppers).then(() => {
@@ -401,7 +401,7 @@ export abstract class SqlTransaction implements NoSqlProvider.DbTransaction {
         });
     }
 
-    internal_getResultFromQuery<T>(sql: string, parameters?: any[]): SyncTasks.Promise<T> {
+    internal_getResultFromQuery<T>(sql: string, parameters?: any[]): SyncTasks.Promise<T|undefined> {
         return this.internal_getResultsFromQuery<T>(sql, parameters)
             .then(rets => rets.length < 1 ? undefined : rets[0]);
     }
@@ -409,7 +409,7 @@ export abstract class SqlTransaction implements NoSqlProvider.DbTransaction {
     getStore(storeName: string): NoSqlProvider.DbStore {
         const storeSchema = _.find(this._schema.stores, store => store.name === storeName);
         if (!storeSchema) {
-            return undefined;
+            throw 'Store not found: ' + storeName;
         }
 
         return new SqlStore(this, storeSchema, this._requiresUnicodeReplacement(), this._supportsFTS3, this._verbose);
@@ -540,7 +540,7 @@ class SqlStore implements NoSqlProvider.DbStore {
         // Empty
     }
 
-    get<T>(key: any | any[]): SyncTasks.Promise<T> {
+    get<T>(key: any | any[]): SyncTasks.Promise<T|undefined> {
         let joinedKey: string;
         const err = _.attempt(() => {
             joinedKey = NoSqlProviderUtils.serializeKeyToString(key, this._schema.primaryKeyPath);
@@ -554,7 +554,7 @@ class SqlStore implements NoSqlProvider.DbStore {
             startTime = Date.now();
         }
 
-        let promise = this._trans.internal_getResultFromQuery<T>('SELECT nsp_data FROM ' + this._schema.name + ' WHERE nsp_pk = ?', [joinedKey]);
+        let promise = this._trans.internal_getResultFromQuery<T>('SELECT nsp_data FROM ' + this._schema.name + ' WHERE nsp_pk = ?', [joinedKey!!!]);
         if (this._verbose) {
             promise = promise.finally(() => {
                 console.log('SqlStore (' + this._schema.name + ') get: (' + (Date.now() - startTime) + 'ms)');
@@ -572,7 +572,7 @@ class SqlStore implements NoSqlProvider.DbStore {
             return SyncTasks.Rejected(err);
         }
 
-        if (joinedKeys.length === 0) {
+        if (joinedKeys!!!.length === 0) {
             return SyncTasks.Resolved<T[]>([]);
         }
 
@@ -581,10 +581,10 @@ class SqlStore implements NoSqlProvider.DbStore {
             startTime = Date.now();
         }
 
-        let qmarks = _.map(joinedKeys, k => '?');
+        const qmarks = _.map(joinedKeys!!!, k => '?');
 
         let promise = this._trans.internal_getResultsFromQuery<T>('SELECT nsp_data FROM ' + this._schema.name + ' WHERE nsp_pk IN (' +
-            qmarks.join(',') + ')', joinedKeys);
+            qmarks.join(',') + ')', joinedKeys!!!);
         if (this._verbose) {
             promise = promise.finally(() => {
                 console.log('SqlStore (' + this._schema.name + ') getMultiple: (' + (Date.now() - startTime) + 'ms): Count: ' + joinedKeys.length);
@@ -665,7 +665,7 @@ class SqlStore implements NoSqlProvider.DbStore {
             _.each(items, (item, itemIndex) => {
                 let key: string;
                 const err = _.attempt(() => {
-                    key = NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._schema.primaryKeyPath);
+                    key = NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._schema.primaryKeyPath)!!!;
                 });
                 if (err) {
                     queries.push(SyncTasks.Rejected<void>(err));
@@ -696,7 +696,7 @@ class SqlStore implements NoSqlProvider.DbStore {
                     }
 
                     let valArgs: string[] = [], insertArgs: string[] = [];
-                    _.each(serializedKeys, val => {
+                    _.each(serializedKeys!!!, val => {
                         valArgs.push(index.includeDataInIndex ? '(?, ?, ?)' : '(?, ?)');
                         insertArgs.push(val);
                         insertArgs.push(key);
@@ -768,7 +768,7 @@ class SqlStore implements NoSqlProvider.DbStore {
     openIndex(indexName: string): NoSqlProvider.DbIndex {
         const indexSchema = _.find(this._schema.indexes, index => index.name === indexName);
         if (!indexSchema) {
-            return undefined;
+            throw 'Index not found: ' + indexName;
         }
 
         return new SqlStoreIndex(this._trans, this._schema, indexSchema, this._supportsFTS3, this._verbose);
@@ -797,7 +797,7 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
     private _indexTableName: string;
     private _keyPath: string | string[];
 
-    constructor(protected _trans: SqlTransaction, storeSchema: NoSqlProvider.StoreSchema, indexSchema: NoSqlProvider.IndexSchema,
+    constructor(protected _trans: SqlTransaction, storeSchema: NoSqlProvider.StoreSchema, indexSchema: NoSqlProvider.IndexSchema|undefined,
             private _supportsFTS3: boolean, private _verbose: boolean) {
         if (!indexSchema) {
             // Going against the PK of the store
@@ -830,7 +830,7 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
         }
     }
 
-    private _handleQuery<T>(sql: string, args: any[], reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<T[]> {
+    private _handleQuery<T>(sql: string, args?: any[], reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<T[]> {
         sql += ' ORDER BY ' + this._queryColumn + (reverse ? ' DESC' : ' ASC');
 
         if (limit) {
@@ -879,7 +879,7 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
             startTime = Date.now();
         }
 
-        let promise = this._handleQuery<T>('SELECT nsp_data FROM ' + this._tableName + ' WHERE ' + this._queryColumn + ' = ?', [joinedKey],
+        let promise = this._handleQuery<T>('SELECT nsp_data FROM ' + this._tableName + ' WHERE ' + this._queryColumn + ' = ?', [joinedKey!!!],
             reverse, limit, offset);
         if (this._verbose) {
             promise = promise.finally(() => {
@@ -907,7 +907,7 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
             startTime = Date.now();
         }
 
-        let promise = this._handleQuery<T>('SELECT nsp_data FROM ' + this._tableName + ' WHERE ' + checks, args, reverse, limit, offset);
+        let promise = this._handleQuery<T>('SELECT nsp_data FROM ' + this._tableName + ' WHERE ' + checks!!!, args!!!, reverse, limit, offset);
         if (this._verbose) {
             promise = promise.finally(() => {
                 console.log('SqlStoreIndex (' + this._rawTableName + '/' + this._indexTableName + ') getRange: (' + (Date.now() - startTime) + 'ms)');
@@ -961,7 +961,7 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
         }
 
         let promise = this._trans.runQuery('SELECT COUNT(*) cnt FROM ' + this._tableName + ' WHERE ' + this._queryColumn
-            + ' = ?', [joinedKey]).then(result => result[0]['cnt']);
+            + ' = ?', [joinedKey!!!]).then(result => result[0]['cnt']);
         if (this._verbose) {
             promise = promise.finally(() => {
                 console.log('SqlStoreIndex (' + this._rawTableName + '/' + this._indexTableName + ') countOnly: (' + (Date.now() - startTime) + 'ms)');
@@ -988,7 +988,7 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
             startTime = Date.now();
         }
 
-        let promise = this._trans.runQuery('SELECT COUNT(*) cnt FROM ' + this._tableName + ' WHERE ' + checks, args)
+        let promise = this._trans.runQuery('SELECT COUNT(*) cnt FROM ' + this._tableName + ' WHERE ' + checks!!!, args!!!)
             .then(result => result[0]['cnt']);
         if (this._verbose) {
             promise = promise.finally(() => {

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -741,17 +741,51 @@ class SqlStore implements NoSqlProvider.DbStore {
             startTime = Date.now();
         }
 
-        // PERF: This is optimizable, but it's of questionable utility
-        const queries = _.map(joinedKeys, joinedKey => {
+        // This was taked from the sqlite documentation
+        const SQLITE_MAX_SQL_LENGTH_IN_BYTES = 1000000;
+
+        // Partition the parameters
+        var arrayOfParams: Array<Array<String>> = [[]];
+        var totalLength = 0;
+        var partitionIndex = 0;
+        joinedKeys.forEach(joinedKey => {
+
+            // Append the new item to the current partition
+            arrayOfParams[partitionIndex].push(joinedKey);
+
+            // Accumulate the length
+            totalLength += joinedKey.length + 2;
+
+            // Make sure we don't exceed the max sql statement limit, if so go to the next partition
+            let didReachSqlStatementLimit = totalLength > (SQLITE_MAX_SQL_LENGTH_IN_BYTES - 200);
+            if (didReachSqlStatementLimit) {
+                totalLength = 0;
+                partitionIndex++;
+                arrayOfParams.push(new Array<String>());
+            }
+        });
+
+        const queries = _.map(arrayOfParams, params => {
             let queries: SyncTasks.Promise<void>[] = [];
+
+            // Generate as many '?' as there are params
+            var sqlPart = '';
+            _.map(params, param => {
+                if (sqlPart.length > 0) {
+                    sqlPart += ',';
+                }
+                sqlPart += '?'
+            });
+
             _.each(this._schema.indexes, index => {
                 if (indexUsesSeparateTable(index, this._supportsFTS3)) {
                     queries.push(this._trans.internal_nonQuery('DELETE FROM ' + this._schema.name + '_' + index.name +
-                        ' WHERE nsp_refpk = ?', [joinedKey]));
+                        ' WHERE nsp_refpk IN (' + sqlPart + ')', params));
                 }
             });
 
-            queries.push(this._trans.internal_nonQuery('DELETE FROM ' + this._schema.name + ' WHERE nsp_pk = ?', [joinedKey]));
+            queries.push(this._trans.internal_nonQuery('DELETE FROM ' + this._schema.name +
+                ' WHERE nsp_pk IN (' + sqlPart + ')', params));
 
             return SyncTasks.all(queries).then(_.noop);
         });

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -774,13 +774,7 @@ class SqlStore implements NoSqlProvider.DbStore {
             let queries: SyncTasks.Promise<void>[] = [];
 
             // Generate as many '?' as there are params
-            var sqlPart = '';
-            _.map(params, param => {
-                if (sqlPart.length > 0) {
-                    sqlPart += ',';
-                }
-                sqlPart += '?'
-            });
+            let sqlPart = Array.apply(null, new Array(params.length)).map(()=> '?').join(',');
 
             _.each(this._schema.indexes, index => {
                 if (indexUsesSeparateTable(index, this._supportsFTS3)) {

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -696,7 +696,7 @@ class SqlStore implements NoSqlProvider.DbStore {
                     }
 
                     let valArgs: string[] = [], insertArgs: string[] = [];
-                    _.each(serializedKeys, val => {
+                    _.each(serializedKeys!!!, val => {
                         valArgs.push(index.includeDataInIndex ? '(?, ?, ?)' : '(?, ?)');
                         insertArgs.push(val);
                         insertArgs.push(key);

--- a/src/TransactionLockHelper.ts
+++ b/src/TransactionLockHelper.ts
@@ -26,7 +26,7 @@ export interface TransactionToken {
 }
 
 interface TransactionTokenInternal extends TransactionToken {
-    completionDefer: SyncTasks.Deferred<void>;
+    completionDefer: SyncTasks.Deferred<void>|undefined;
 }
 
 class TransactionLockHelper {

--- a/src/WebSqlProvider.ts
+++ b/src/WebSqlProvider.ts
@@ -101,7 +101,7 @@ export class WebSqlProvider extends SqlProviderBase.SqlProviderBase {
             (trans: SQLTransaction) => {
                 ourTrans = new WebSqlTransaction(trans, finishDefer.promise(), this._schema, this._verbose, 999, this._supportsFTS3);
                 deferred.resolve(ourTrans);
-            }, (err) => {
+            }, (err: SQLError) => {
                 if (ourTrans) {
                     // Got an error from inside the transaction.  Error out all pending queries on the 
                     // transaction since they won't exit out gracefully for whatever reason.

--- a/src/dependencies.d.ts
+++ b/src/dependencies.d.ts
@@ -41,9 +41,9 @@ interface SQLTransactionErrorCallback {
 interface Database {
     version: string;
 
-    changeVersion(oldVersion: string, newVersion: string, callback?: SQLTransactionCallback, errorCallback?: SQLTransactionErrorCallback, successCallback?: SQLVoidCallback);
-    transaction(callback?: SQLTransactionCallback, errorCallback?: SQLTransactionErrorCallback, successCallback?: SQLVoidCallback);
-    readTransaction(callback?: SQLTransactionCallback, errorCallback?: SQLTransactionErrorCallback, successCallback?: SQLVoidCallback);
+    changeVersion(oldVersion: string, newVersion: string, callback?: SQLTransactionCallback, errorCallback?: SQLTransactionErrorCallback, successCallback?: SQLVoidCallback): void;
+    transaction(callback?: SQLTransactionCallback, errorCallback?: SQLTransactionErrorCallback, successCallback?: SQLVoidCallback): void;
+    readTransaction(callback?: SQLTransactionCallback, errorCallback?: SQLTransactionErrorCallback, successCallback?: SQLVoidCallback): void;
 }
 
 interface SQLStatementCallback {
@@ -55,7 +55,7 @@ interface SQLStatementErrorCallback {
 }
 
 interface SQLTransaction {
-    executeSql(sqlStatement: string, arguments?: any[], callback?: SQLStatementCallback, errorCallback?: SQLStatementErrorCallback);
+    executeSql(sqlStatement: string, arguments?: any[], callback?: SQLStatementCallback, errorCallback?: SQLStatementErrorCallback): void;
 }
 
 declare enum SQLErrors {

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -45,6 +45,8 @@ function openProvider(providerName: string, schema: NoSqlProvider.DbSchema, wipe
     // } else if (providerName === 'reactnative') {
     //     var reactNativeSqliteProvider = require('react-native-sqlite-storage');
     //     provider = new CordovaNativeSqliteProvider(reactNativeSqliteProvider);
+    } else {
+        throw 'Provider not found for name: ' + providerName;
     }
     const dbName = providerName.indexOf('sqlite3memory') !== -1 ? ':memory:' : 'test';
     return NoSqlProvider.openListOfProviders([provider], dbName, schema, wipeFirst, false);
@@ -112,7 +114,7 @@ describe('NoSqlProvider', function () {
             describe('Data Manipulation', () => {
                 // Setter should set the testable parameter on the first param to the value in the second param, and third param to the
                 // second index column for compound indexes.
-                var tester = (prov: NoSqlProvider.DbProvider, indexName: string, compound: boolean,
+                var tester = (prov: NoSqlProvider.DbProvider, indexName: string|undefined, compound: boolean,
                     setter: (obj: any, indexval1: string, indexval2: string) => void) => {
                     var putters = [1, 2, 3, 4, 5].map(v => {
                         var obj: any = { val: 'val' + v };
@@ -281,7 +283,7 @@ describe('NoSqlProvider', function () {
                             return prov.get<any>('test', 'a').then(ret => {
                                 assert.equal(ret.val, 'b');
 
-                                return prov.getAll<any>('test').then(ret2 => {
+                                return prov.getAll<any>('test', undefined).then(ret2 => {
                                     assert.equal(ret2.length, 1);
                                     assert.equal(ret2[0].val, 'b');
 
@@ -303,7 +305,7 @@ describe('NoSqlProvider', function () {
                         ]
                     }, true).then(prov => {
                         return prov.put('test', []).then(() => {
-                            return prov.getAll('test').then(rets => {
+                            return prov.getAll('test', undefined).then(rets => {
                                 assert(!!rets);
                                 assert.equal(rets.length, 0);
                                 return prov.getMultiple<any>('test', []).then(rets => {
@@ -327,15 +329,15 @@ describe('NoSqlProvider', function () {
                         ]
                     }, true).then(prov => {
                         return prov.put('test', [1, 2, 3, 4, 5].map(i => { return { id: 'a' + i }; })).then(() => {
-                            return prov.getAll('test').then(rets => {
+                            return prov.getAll('test', undefined).then(rets => {
                                 assert(!!rets);
                                 assert.equal(rets.length, 5);
                                 return prov.remove('test', 'a1').then(() => {
-                                    return prov.getAll('test').then(rets => {
+                                    return prov.getAll('test', undefined).then(rets => {
                                         assert(!!rets);
                                         assert.equal(rets.length, 4);
                                         return prov.remove('test', ['a3', 'a4', 'a2']).then(() => {
-                                            return prov.getAll<any>('test').then(rets => {
+                                            return prov.getAll<any>('test', undefined).then(rets => {
                                                 assert(!!rets);
                                                 assert.equal(rets.length, 1);
                                                 assert.equal(rets[0].id, 'a5');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,17 @@
         "noResolve": false,
         "module": "commonjs",
         "target": "es5",
+        "outDir": "dist/",
+        "typeRoots": [
+            "node_modules/@types"
+        ],
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
         "noUnusedLocals": true,
-        "outDir": "dist/"
+        "forceConsistentCasingInFileNames": true,
+        
+        "strictNullChecks": false
     },
 
     "filesGlob": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
         "noUnusedLocals": true,
         "forceConsistentCasingInFileNames": true,
         
-        "strictNullChecks": false
+        "strictNullChecks": true
     },
 
     "filesGlob": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,22 +8,22 @@ var webpackConfig = {
         filename: './NoSQLProviderTestsPack.js',
     },
 
+    externals: [ 'sqlite3', 'indexeddb-js', 'fs' ],
+    
     resolve: {
-        root: [
+        modules: [
             path.resolve('./src'),
             path.resolve('./node_modules')
         ],
-        extensions: ['', '.ts', '.js']
+        extensions: ['.ts', '.tsx', '.js']
     },
     
-    externals: [ 'sqlite3', 'indexeddb-js', 'fs' ],
-    
     module: {
-        loaders: [{
+        rules: [{
             // Compile TS.
             test: /\.tsx?$/, 
             exclude: /node_modules/,
-            loader: 'ts-loader'
+            loader: 'awesome-typescript-loader'
         }]
     }  
 };


### PR DESCRIPTION
The remove() API takes a list of IDs to remove. Before this change it executed each id as a separate sql command. 

This change is to instead use the DELETE FROM table WHERE key IN (key1, key2, ...) syntax and instead issue minimal number of commands.