### PR TITLE
Issue deletes in chunks instead of individually using the DELETE x IN (list_of_ids)

### DIFF
--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -535,6 +535,10 @@ export abstract class SqliteSqlTransaction extends SqlTransaction {
 // DbStore implementation for the SQL-based DbProviders.  Implements the getters/setters against the transaction object and all of the
 // glue for index/compound key support.
 class SqlStore implements NoSqlProvider.DbStore {
+
+    // This was taked from the sqlite documentation
+    private readonly SQLITE_MAX_SQL_LENGTH_IN_BYTES = 1000000;
+
     constructor(private _trans: SqlTransaction, private _schema: NoSqlProvider.StoreSchema, private _replaceUnicode: boolean,
             private _supportsFTS3: boolean, private _verbose: boolean) {
         // Empty
@@ -741,9 +745,6 @@ class SqlStore implements NoSqlProvider.DbStore {
             startTime = Date.now();
         }
 
-        // This was taked from the sqlite documentation
-        const SQLITE_MAX_SQL_LENGTH_IN_BYTES = 1000000;
-
         // Partition the parameters
         var arrayOfParams: Array<Array<String>> = [[]];
         var totalLength = 0;
@@ -760,7 +761,7 @@ class SqlStore implements NoSqlProvider.DbStore {
             totalItems++;
 
             // Make sure we don't exceed the following sqlite limits, if so go to the next partition
-            let didReachSqlStatementLimit = totalLength > (SQLITE_MAX_SQL_LENGTH_IN_BYTES - 200);
+            let didReachSqlStatementLimit = totalLength > (this.SQLITE_MAX_SQL_LENGTH_IN_BYTES - 200);
             let didExceedMaxVariableCount = totalItems >= this._trans.internal_getMaxVariables();
             if (didReachSqlStatementLimit || didExceedMaxVariableCount) {
                 totalLength = 0;

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -15,6 +15,9 @@ import NoSqlProviderUtils = require('./NoSqlProviderUtils');
 
 const schemaVersionKey = 'schemaVersion';
 
+// This was taked from the sqlite documentation
+const SQLITE_MAX_SQL_LENGTH_IN_BYTES = 1000000;
+
 interface IndexMetadata {
     key: string;
     storeName: string;
@@ -535,10 +538,6 @@ export abstract class SqliteSqlTransaction extends SqlTransaction {
 // DbStore implementation for the SQL-based DbProviders.  Implements the getters/setters against the transaction object and all of the
 // glue for index/compound key support.
 class SqlStore implements NoSqlProvider.DbStore {
-
-    // This was taked from the sqlite documentation
-    private readonly SQLITE_MAX_SQL_LENGTH_IN_BYTES = 1000000;
-
     constructor(private _trans: SqlTransaction, private _schema: NoSqlProvider.StoreSchema, private _replaceUnicode: boolean,
             private _supportsFTS3: boolean, private _verbose: boolean) {
         // Empty
@@ -761,7 +760,7 @@ class SqlStore implements NoSqlProvider.DbStore {
             totalItems++;
 
             // Make sure we don't exceed the following sqlite limits, if so go to the next partition
-            let didReachSqlStatementLimit = totalLength > (this.SQLITE_MAX_SQL_LENGTH_IN_BYTES - 200);
+            let didReachSqlStatementLimit = totalLength > (SQLITE_MAX_SQL_LENGTH_IN_BYTES - 200);
             let didExceedMaxVariableCount = totalItems >= this._trans.internal_getMaxVariables();
             if (didReachSqlStatementLimit || didExceedMaxVariableCount) {
                 totalLength = 0;

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -728,7 +728,7 @@ class SqlStore implements NoSqlProvider.DbStore {
     }
 
     remove(keyOrKeys: any | any[]): SyncTasks.Promise<void> {
-        let joinedKeys: string[];
+        let joinedKeys: string[] = [];
         const err = _.attempt(() => {
             joinedKeys = NoSqlProviderUtils.formListOfSerializedKeys(keyOrKeys, this._schema.primaryKeyPath);
         });
@@ -741,17 +741,50 @@ class SqlStore implements NoSqlProvider.DbStore {
             startTime = Date.now();
         }
 
-        // PERF: This is optimizable, but it's of questionable utility
-        const queries = _.map(joinedKeys!!!, joinedKey => {
+        // This was taked from the sqlite documentation
+        const SQLITE_MAX_SQL_LENGTH_IN_BYTES = 1000000;
+
+        // Partition the parameters
+        var arrayOfParams: Array<Array<String>> = [[]];
+        var totalLength = 0;
+        var totalItems = 0;
+        var partitionIndex = 0;
+        joinedKeys.forEach(joinedKey => {
+
+            // Append the new item to the current partition
+            arrayOfParams[partitionIndex].push(joinedKey);
+
+            // Accumulate the length
+            totalLength += joinedKey.length + 2;
+
+            totalItems++;
+
+            // Make sure we don't exceed the following sqlite limits, if so go to the next partition
+            let didReachSqlStatementLimit = totalLength > (SQLITE_MAX_SQL_LENGTH_IN_BYTES - 200);
+            let didExceedMaxVariableCount = totalItems >= this._trans.internal_getMaxVariables();
+            if (didReachSqlStatementLimit || didExceedMaxVariableCount) {
+                totalLength = 0;
+                totalItems = 0;
+                partitionIndex++;
+                arrayOfParams.push(new Array<String>());
+            }
+        });
+
+        const queries = _.map(arrayOfParams, params => {
             let queries: SyncTasks.Promise<void>[] = [];
+
+            // Generate as many '?' as there are params
+            let sqlPart = Array.apply(null, new Array(params.length)).map(()=> '?').join(',');
+
             _.each(this._schema.indexes, index => {
                 if (indexUsesSeparateTable(index, this._supportsFTS3)) {
                     queries.push(this._trans.internal_nonQuery('DELETE FROM ' + this._schema.name + '_' + index.name +
-                        ' WHERE nsp_refpk = ?', [joinedKey]));
+                        ' WHERE nsp_refpk IN (' + sqlPart + ')', params));
                 }
             });
 
-            queries.push(this._trans.internal_nonQuery('DELETE FROM ' + this._schema.name + ' WHERE nsp_pk = ?', [joinedKey]));
+            queries.push(this._trans.internal_nonQuery('DELETE FROM ' + this._schema.name +
+                ' WHERE nsp_pk IN (' + sqlPart + ')', params));
 
             return SyncTasks.all(queries).then(_.noop);
         });


### PR DESCRIPTION
The remove() API takes a list of IDs to remove. Before this change it executed each id as a separate sql command.

This change is to instead use the DELETE FROM table WHERE key IN (key1, key2, ...) syntax and instead issue minimal number of commands.