### PR TITLE
0.6.0: Changing to not have all of the various getters have templated…

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosqlprovider",
-  "version": "0.5.21",
+  "version": "0.6.0",
   "description": "A cross-browser/platform indexeddb-like client library",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {
@@ -14,7 +14,7 @@
     "@types/lodash": "^4.14.62",
     "@types/sqlite3": "^2.2.32",
     "lodash": "^4.0.0",
-    "synctasks": "^0.2.12"
+    "synctasks": "^0.2.23"
   },
   "devDependencies": {
     "@types/mocha": "2.2.38",

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -11,6 +11,7 @@ import SyncTasks = require('synctasks');
 
 import FullTextSearchHelpers = require('./FullTextSearchHelpers');
 import NoSqlProvider = require('./NoSqlProvider');
+import { ItemType, KeyPathType, KeyType } from './NoSqlProvider';
 import NoSqlProviderUtils = require('./NoSqlProviderUtils');
 import TransactionLockHelper, { TransactionToken } from './TransactionLockHelper';
 
@@ -390,7 +391,7 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
         // NOP
     }
 
-    get<T>(key: any | any[]): SyncTasks.Promise<T> {
+    get(key: KeyType): SyncTasks.Promise<ItemType|undefined> {
         if (this._fakeComplicatedKeys && NoSqlProviderUtils.isCompoundKeyPath(this._schema.primaryKeyPath)) {
             const err = _.attempt(() => {
                 key = NoSqlProviderUtils.serializeKeyToString(key, this._schema.primaryKeyPath);
@@ -400,11 +401,11 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
             }
         }
 
-        return IndexedDbProvider.WrapRequest<T>(this._store.get(key))
+        return IndexedDbProvider.WrapRequest(this._store.get(key))
             .then(val => removeFullTextMetadataAndReturn(this._schema, val));
     }
 
-    getMultiple<T>(keyOrKeys: any | any[]): SyncTasks.Promise<T[]> {
+    getMultiple(keyOrKeys: KeyType|KeyType[]): SyncTasks.Promise<ItemType[]> {
         let keys: any[];
         const err = _.attempt(() => {
             keys = NoSqlProviderUtils.formListOfKeys(keyOrKeys, this._schema.primaryKeyPath);
@@ -419,11 +420,11 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
 
         // There isn't a more optimized way to do this with indexeddb, have to get the results one by one
         return SyncTasks.all(_.map(keys!!!, key =>
-            IndexedDbProvider.WrapRequest<T>(this._store.get(key)).then(val => removeFullTextMetadataAndReturn(this._schema, val))))
+            IndexedDbProvider.WrapRequest(this._store.get(key)).then(val => removeFullTextMetadataAndReturn(this._schema, val))))
             .then(_.compact);
     }
 
-    put(itemOrItems: any | any[]): SyncTasks.Promise<void> {
+    put(itemOrItems: ItemType|ItemType[]): SyncTasks.Promise<void> {
         let items = NoSqlProviderUtils.arrayify(itemOrItems);
 
         let promises: SyncTasks.Promise<void>[] = [];
@@ -435,7 +436,7 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
                 if (this._fakeComplicatedKeys) {
                     // Fill out any compound-key indexes
                     if (NoSqlProviderUtils.isCompoundKeyPath(this._schema.primaryKeyPath)) {
-                        item['nsp_pk'] = NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._schema.primaryKeyPath);
+                        (item as any)['nsp_pk'] = NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._schema.primaryKeyPath);
                     }
 
                     _.each(this._schema.indexes, index => {
@@ -491,14 +492,14 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
                                     return SyncTasks.all(iputters);
                                 }).then(_.noop));
                         } else if (NoSqlProviderUtils.isCompoundKeyPath(index.keyPath)) {
-                            item[IndexPrefix + index.name] = NoSqlProviderUtils.getSerializedKeyForKeypath(item, index.keyPath);
+                            (item as any)[IndexPrefix + index.name] = NoSqlProviderUtils.getSerializedKeyForKeypath(item, index.keyPath);
                         }
                         return true;
                     });
                 } else {
                     _.each(this._schema.indexes, index => {
                         if (index.fullText) {
-                            item[IndexPrefix + index.name] =
+                            (item as any)[IndexPrefix + index.name] =
                                 FullTextSearchHelpers.getFullTextIndexWordsForItem(<string>index.keyPath, item);
                         }
                     });
@@ -524,7 +525,7 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
         return SyncTasks.all(promises).then(_.noop);
     }
 
-    remove(keyOrKeys: any | any[]): SyncTasks.Promise<void> {
+    remove(keyOrKeys: KeyType|KeyType[]): SyncTasks.Promise<void> {
         let keys: any[];
         const err = _.attempt(() => {
             keys = NoSqlProviderUtils.formListOfKeys(keyOrKeys, this._schema.primaryKeyPath);
@@ -546,16 +547,16 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
                         let promises = _.map(_.filter(this._schema.indexes, index => !!index.multiEntry), index => {
                             let indexStore = _.find(this._indexStores, store => store.name === this._schema.name + '_' + index.name)!!!;
 
-                            let refKey: string;
+                            let refKey: KeyType;
                             const err = _.attempt(() => {
 
                                 // We need to reference the PK of the actual row we're using here, so calculate the actual PK -- if it's
                                 // compound, we're already faking complicated keys, so we know to serialize it to a string.  If not, use the
                                 // raw value.
-                                refKey = NoSqlProviderUtils.getKeyForKeypath(item, this._schema.primaryKeyPath);
-                                if (_.isArray(this._schema.primaryKeyPath)) {
-                                    refKey = NoSqlProviderUtils.serializeKeyToString(refKey, this._schema.primaryKeyPath);
-                                }
+                                const tempRefKey = NoSqlProviderUtils.getKeyForKeypath(item, this._schema.primaryKeyPath)!!!;
+                                refKey = _.isArray(this._schema.primaryKeyPath) ? 
+                                    NoSqlProviderUtils.serializeKeyToString(tempRefKey, this._schema.primaryKeyPath) :
+                                    tempRefKey;
                             });
                             if (err) {
                                 return SyncTasks.Rejected<void>(err);
@@ -622,32 +623,32 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
 // result APIs to get their result list.  Also added ability to use an "index" for opening the primary key on a store.
 class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
     constructor(private _store: IDBIndex | IDBObjectStore, indexSchema: NoSqlProvider.IndexSchema|undefined,
-            primaryKeyPath: string | string[], private _fakeComplicatedKeys: boolean, private _fakedOriginalStore?: IDBObjectStore) {
+            primaryKeyPath: KeyPathType, private _fakeComplicatedKeys: boolean, private _fakedOriginalStore?: IDBObjectStore) {
         super(indexSchema, primaryKeyPath);
     }
 
-    private _resolveCursorResult<T>(req: IDBRequest, limit?: number, offset?: number): SyncTasks.Promise<T[]> {
+    private _resolveCursorResult(req: IDBRequest, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
         if (this._fakeComplicatedKeys && this._fakedOriginalStore) {
             // Get based on the keys from the index store, which have refkeys that point back to the original store
             return IndexedDbIndex.getFromCursorRequest<{ key: string, refkey: any }>(req, limit, offset).then(rets => {
                 // Now get the original items using the refkeys from the index store, which are PKs on the main store
-                const getters = _.map(rets, ret => IndexedDbProvider.WrapRequest<T>(this._fakedOriginalStore!!!.get(ret.refkey)));
+                const getters = _.map(rets, ret => IndexedDbProvider.WrapRequest(this._fakedOriginalStore!!!.get(ret.refkey)));
                 return SyncTasks.all(getters);
             });
         } else {
-            return IndexedDbIndex.getFromCursorRequest<T>(req, limit, offset);
+            return IndexedDbIndex.getFromCursorRequest(req, limit, offset);
         }
     }
 
-    getAll<T>(reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<T[]> {
+    getAll(reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
         // ************************* Don't change this null to undefined, IE chokes on it... *****************************
         // ************************* Don't change this null to undefined, IE chokes on it... *****************************
         // ************************* Don't change this null to undefined, IE chokes on it... *****************************
         const req = this._store.openCursor(null!!!, reverse ? 'prev' : 'next');
-        return this._resolveCursorResult<T>(req, limit, offset);
+        return this._resolveCursorResult(req, limit, offset);
     }
 
-    getOnly<T>(key: any | any[], reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<T[]> {
+    getOnly(key: KeyType, reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
         let keyRange: any;
         const err = _.attempt(() => {
             keyRange = this._getKeyRangeForOnly(key);
@@ -657,19 +658,19 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
         }
 
         const req = this._store.openCursor(keyRange, reverse ? 'prev' : 'next');
-        return this._resolveCursorResult<T>(req, limit, offset);
+        return this._resolveCursorResult(req, limit, offset);
     }
 
     // Warning: This function can throw, make sure to trap.
-    private _getKeyRangeForOnly(key: any|any[]): IDBKeyRange {
+    private _getKeyRangeForOnly(key: KeyType): IDBKeyRange {
         if (this._fakeComplicatedKeys && NoSqlProviderUtils.isCompoundKeyPath(this._keyPath)) {
             return IDBKeyRange.only(NoSqlProviderUtils.serializeKeyToString(key, this._keyPath));
         }
         return IDBKeyRange.only(key);
     }
 
-    getRange<T>(keyLowRange: any | any[], keyHighRange: any | any[], lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
-            reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<T[]> {
+    getRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
+            reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
         let keyRange: any;
         const err = _.attempt(() => {
             keyRange = this._getKeyRangeForRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
@@ -679,11 +680,11 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
         }
 
         const req = this._store.openCursor(keyRange, reverse ? 'prev' : 'next');
-        return this._resolveCursorResult<T>(req, limit, offset);
+        return this._resolveCursorResult(req, limit, offset);
     }
 
     // Warning: This function can throw, make sure to trap.
-    private _getKeyRangeForRange(keyLowRange: any | any[], keyHighRange: any | any[], lowRangeExclusive?: boolean,
+    private _getKeyRangeForRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean,
                 highRangeExclusive?: boolean)
             : IDBKeyRange {
         if (this._fakeComplicatedKeys && NoSqlProviderUtils.isCompoundKeyPath(this._keyPath)) {
@@ -700,7 +701,7 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
         return this._countRequest(req);
     }
 
-    countOnly(key: any|any[]): SyncTasks.Promise<number> {
+    countOnly(key: KeyType): SyncTasks.Promise<number> {
         let keyRange: any;
         const err = _.attempt(() => {
             keyRange = this._getKeyRangeForOnly(key);
@@ -713,7 +714,7 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
         return this._countRequest(req);
     }
 
-    countRange(keyLowRange: any|any[], keyHighRange: any|any[], lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
+    countRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
             : SyncTasks.Promise<number> {
         let keyRange: any;
         const err = _.attempt(() => {
@@ -728,7 +729,7 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
     }
 
     static getFromCursorRequest<T>(req: IDBRequest, limit?: number, offset?: number): SyncTasks.Promise<T[]> {
-        let outList: any[] = [];
+        let outList: T[] = [];
         return this.iterateOverCursorRequest(req, cursor => {
             // Typings on cursor are wrong...
             outList.push((cursor as any).value);

--- a/src/NoSqlProviderUtils.ts
+++ b/src/NoSqlProviderUtils.ts
@@ -8,7 +8,9 @@
 
 import _ = require('lodash');
 
-export function isArray(obj: any): boolean {
+import { KeyComponentType, KeyPathType, KeyType } from './NoSqlProvider';
+
+export function isArray<T>(obj: T|T[]): obj is T[] {
     return (Object.prototype.toString.call(obj) === '[object Array]');
 }
 
@@ -22,7 +24,7 @@ const keypathJoinerString = '%&';
 
 // This function computes a serialized single string value for a keypath on an object.  This is used for generating ordered string keys
 // for compound (or non-compound) values.
-export function getSerializedKeyForKeypath(obj: any, keyPathRaw: string | string[]): string|undefined {
+export function getSerializedKeyForKeypath(obj: any, keyPathRaw: KeyPathType): string|undefined {
     const values = getKeyForKeypath(obj, keyPathRaw);
     if (values === undefined) {
         return undefined;
@@ -31,7 +33,7 @@ export function getSerializedKeyForKeypath(obj: any, keyPathRaw: string | string
     return serializeKeyToString(values, keyPathRaw);
 }
 
-export function getKeyForKeypath(obj: any, keyPathRaw: string | string[]): any {
+export function getKeyForKeypath(obj: any, keyPathRaw: KeyPathType): KeyType|undefined {
     const keyPathArray = arrayify(keyPathRaw);
 
     const values = _.map(keyPathArray, kp => getValueForSingleKeypath(obj, kp));
@@ -48,15 +50,15 @@ export function getKeyForKeypath(obj: any, keyPathRaw: string | string[]): any {
 }
 
 // Internal helper function for getting a value out of a standard keypath.
-export function getValueForSingleKeypath(obj: any, keyPath: string): any {
-    return _.get<any>(obj, keyPath, undefined);
+export function getValueForSingleKeypath(obj: any, singleKeyPath: string): any {
+    return _.get<any>(obj, singleKeyPath, undefined);
 }
 
-export function isCompoundKeyPath(keyPath: string | string[]) {
+export function isCompoundKeyPath(keyPath: KeyPathType) {
     return isArray(keyPath) && keyPath.length > 1;
 }
 
-export function formListOfKeys(keyOrKeys: any | any[], keyPath: string | string[]): any[] {
+export function formListOfKeys(keyOrKeys: KeyType|KeyType[], keyPath: KeyPathType): any[] {
     if (isCompoundKeyPath(keyPath)) {
         if (!isArray(keyOrKeys)) {
             throw new Error('formListOfKeys called with a compound keypath (' + JSON.stringify(keyPath) +
@@ -75,7 +77,7 @@ export function formListOfKeys(keyOrKeys: any | any[], keyPath: string | string[
     return arrayify(keyOrKeys);
 }
 
-export function serializeValueToOrderableString(val: any) {
+export function serializeValueToOrderableString(val: KeyComponentType): string {
     if (typeof val === 'number') {
         return 'A' + serializeNumberToOrderableString(val as number);
     }
@@ -126,7 +128,7 @@ export function serializeNumberToOrderableString(n: number) {
     }
 }
 
-export function serializeKeyToString(key: any | any[], keyPath: string | string[]): string {
+export function serializeKeyToString(key: KeyType, keyPath: KeyPathType): string {
     if (isCompoundKeyPath(keyPath)) {
         if (isArray(key)) {
             return _.map(key, k => serializeValueToOrderableString(k)).join(keypathJoinerString);
@@ -144,7 +146,7 @@ export function serializeKeyToString(key: any | any[], keyPath: string | string[
     }
 }
 
-export function formListOfSerializedKeys(keyOrKeys: any | any[], keyPath: string | string[]): string[] {
+export function formListOfSerializedKeys(keyOrKeys: KeyType|KeyType[], keyPath: KeyPathType): string[] {
     return _.map(formListOfKeys(keyOrKeys, keyPath), key => serializeKeyToString(key, keyPath));
 }
 

--- a/src/StoreHelpers.ts
+++ b/src/StoreHelpers.ts
@@ -1,0 +1,128 @@
+ /**
+ * StoreHelpers.ts
+ * Author: David de Regt
+ * Copyright: Microsoft 2017
+ *
+ * Reusable helper classes for clients of NoSqlProvider to build more type-safe stores/indexes.
+ */
+
+import SyncTasks = require('synctasks');
+
+import NoSqlProvider = require('./NoSqlProvider');
+import { ItemType, KeyType } from './NoSqlProvider';
+
+export var ErrorCatcher: ((err: any) => SyncTasks.Promise<any>)|undefined = undefined;
+
+// Remove parens from full text search, crashes on React Native....
+const FullTextSanitizeRegex = /[()]/g;
+
+// Encodes related type info into the Store/Index name.
+// The actual value is just a string, but the type system can extract this extra info.
+export type DBStore<Name extends string, ObjectType, KeyFormat> = string & { name?: Name, objectType?: ObjectType, keyFormat?: KeyFormat };
+export type DBIndex<Store extends DBStore<string, any, any>, IndexKeyFormat> = string & { store?: Store, indexKeyFormat?: IndexKeyFormat };
+
+export class SimpleTransactionIndexHelper<ObjectType extends ItemType, IndexKeyFormat extends KeyType> {
+    constructor(private _index: NoSqlProvider.DbIndex) {
+        // Nothing to see here
+    }
+
+    getAll(reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
+        let promise = this._index.getAll(reverse, limit, offset) as SyncTasks.Promise<ObjectType[]>;
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    getOnly(key: IndexKeyFormat, reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
+        let promise = this._index.getOnly(key, reverse, limit, offset) as SyncTasks.Promise<ObjectType[]>;
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    getRange(keyLowRange: IndexKeyFormat, keyHighRange: IndexKeyFormat,
+            lowRangeExclusive?: boolean, highRangeExclusive?: boolean, reverse?: boolean, limit?: number, offset?: number)
+            : SyncTasks.Promise<ObjectType[]> {
+        let promise = this._index.getRange(keyLowRange, keyHighRange, lowRangeExclusive,
+            highRangeExclusive, reverse, limit, offset) as SyncTasks.Promise<ObjectType[]>;
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    countAll(): SyncTasks.Promise<number> {
+        let promise = this._index.countAll();
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    countOnly(key: IndexKeyFormat): SyncTasks.Promise<number> {
+        let promise = this._index.countOnly(key);
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    countRange(keyLowRange: IndexKeyFormat, keyHighRange: IndexKeyFormat,
+            lowRangeExclusive?: boolean, highRangeExclusive?: boolean): SyncTasks.Promise<number> {
+        let promise = this._index.countRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    fullTextSearch(searchPhrase: string, resolution?: NoSqlProvider.FullTextTermResolution,
+            limit?: number): SyncTasks.Promise<ObjectType[]> {
+        // Sanitize input by removing parens, the plugin on RN explodes
+        let promise = this._index.fullTextSearch(searchPhrase.replace(FullTextSanitizeRegex, ''),
+            resolution, limit) as SyncTasks.Promise<ObjectType[]>;
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+}
+
+export class SimpleTransactionStoreHelper<StoreName extends string, ObjectType extends ItemType, KeyFormat extends KeyType> {
+    constructor(private _store: NoSqlProvider.DbStore, storeName /* Force type-checking */: DBStore<StoreName, ObjectType, KeyFormat>) {
+        // Nothing to see here
+    }
+
+    get(key: KeyFormat): SyncTasks.Promise<ObjectType|undefined> {
+        let promise = this._store.get(key) as SyncTasks.Promise<ObjectType|undefined>;
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    getAll(): SyncTasks.Promise<ObjectType[]> {
+        let promise = this._store.openPrimaryKey().getAll() as SyncTasks.Promise<ObjectType[]>;
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    getOnly(key: KeyFormat, reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
+        let promise = this._store.openPrimaryKey().getOnly(key, reverse, limit, offset) as SyncTasks.Promise<ObjectType[]>;
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    getRange(keyLowRange: KeyFormat, keyHighRange: KeyFormat,
+            lowRangeExclusive?: boolean, highRangeExclusive?: boolean, reverse?: boolean, limit?: number, offset?: number)
+            : SyncTasks.Promise<ObjectType[]> {
+        let promise = this._store.openPrimaryKey().getRange(keyLowRange, keyHighRange,
+            lowRangeExclusive, highRangeExclusive, reverse, limit, offset) as SyncTasks.Promise<ObjectType[]>;
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    getMultiple(keyOrKeys: KeyFormat|KeyFormat[]): SyncTasks.Promise<ObjectType[]> {
+        let promise = this._store.getMultiple(keyOrKeys) as SyncTasks.Promise<ObjectType[]>;
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    openIndex<IndexKeyFormat extends KeyType>(indexName: DBIndex<DBStore<StoreName, ObjectType, KeyFormat>, IndexKeyFormat>)
+            : SimpleTransactionIndexHelper<ObjectType, IndexKeyFormat> {
+        return new SimpleTransactionIndexHelper<ObjectType, IndexKeyFormat>(this._store.openIndex(indexName));
+    }
+
+    openPrimaryKey(): SimpleTransactionIndexHelper<ObjectType, KeyFormat> {
+        return new SimpleTransactionIndexHelper<ObjectType, KeyFormat>(this._store.openPrimaryKey());
+    }
+
+    put(itemOrItems: ObjectType|ReadonlyArray<ObjectType>): SyncTasks.Promise<void> {
+        let promise = this._store.put(itemOrItems);
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    remove(keyOrKeys: KeyFormat|KeyFormat[]): SyncTasks.Promise<void> {
+        let promise = this._store.remove(keyOrKeys);
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    clearAllData(): SyncTasks.Promise<void> {
+        let promise = this._store.clearAllData();
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+}

--- a/src/WebSqlProvider.ts
+++ b/src/WebSqlProvider.ts
@@ -6,6 +6,7 @@
  * NoSqlProvider provider setup for WebSql, a browser storage backing.
  */
 
+import _ = require('lodash');
 import SyncTasks = require('synctasks');
 
 import NoSqlProvider = require('./NoSqlProvider');
@@ -148,6 +149,6 @@ class WebSqlTransaction extends SqlProviderBase.SqliteSqlTransaction {
     abort(): void {
         // The only way to rollback a websql transaction is by forcing an error (which rolls back the trans):
         // http://stackoverflow.com/questions/16225320/websql-dont-rollback
-        this.runQuery('ERROR ME TO DEATH').catch(() => undefined);
+        this.runQuery('ERROR ME TO DEATH').always(_.noop);
     }
 }


### PR DESCRIPTION
… T types.  You really have no idea what is being returned from the database, so the caller can decide what to coerce the return types into.  Lots of cleanup by adding types for KeyType, ItemType, and KeyPathType.  Updated to latest SyncTasks to fix some catch bug issues.  Added StoreHelpers to help strongly-type stores and indexes in absence of cheater <T> types on getters.