### PR TITLE
Full Text Search bug fixes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosqlprovider",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "A cross-browser/platform indexeddb-like client library",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/lodash": "^4.14.80",
     "@types/sqlite3": "^2.2.32",
     "lodash": "^4.0.0",
-    "regexp-i18n": "1.1.0",
+    "regexp-i18n": "1.1.1",
     "synctasks": "^0.3.0"
   },
   "devDependencies": {

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -1055,6 +1055,9 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
         }
 
         const terms = FullTextSearchHelpers.breakAndNormalizeSearchPhrase(searchPhrase);
+        if (terms.length === 0) {
+            return SyncTasks.Resolved([]);
+        }
 
         let promise: SyncTasks.Promise<ItemType[]>;
         if (this._supportsFTS3) {

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -1760,6 +1760,11 @@ describe('NoSqlProvider', function () {
                                 // i18n digits test case
                                 id: 'a6',
                                 txt: '߂i18nDigits߂'
+                            },
+                            {
+                                // Test data to make sure that we don't search for empty strings (... used to put empty string to the index)
+                                id: 'a7',
+                                txt: 'User1, User2, User3 ...'
                             }
                         ]).then(() => {
                         const p1 = prov.fullTextSearch('test', 'i', 'brown').then((res: any[]) => {
@@ -1873,8 +1878,13 @@ describe('NoSqlProvider', function () {
                             assert.equal(res.length, 1);
                         });
 
+                        // This is an empty string test. All special symbols will be replaced so this is technically empty string search.
+                        const p31 = prov.fullTextSearch('test', 'i', '!@#$%$', NoSqlProvider.FullTextTermResolution.Or).then(res => {
+                            assert.equal(res.length, 0);
+                        }); 
+
                         return SyncTasks.all([p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20,
-                                p21, p22, p23, p24, p25, p26, p27, p28, p29, p30]).then(() => {
+                                p21, p22, p23, p24, p25, p26, p27, p28, p29, p30, p31]).then(() => {
                             return prov.close();
                         });
                     });


### PR DESCRIPTION
- Bug fix: upgraded to the i18n version which doesn't strip the numbers at the start of the string
- Bug fix: We don't add empty strings to the index anymore.
- Empty search attempt immediately resolves with an empty result for all providers.
- Added test for empty string search.