### PR TITLE
Allow different return values from transaction error handler

### DIFF
--- a/src/CordovaNativeSqliteProvider.ts
+++ b/src/CordovaNativeSqliteProvider.ts
@@ -164,6 +164,11 @@ class CordovaNativeSqliteTransaction extends SqlProviderBase.SqliteSqlTransactio
         (this._trans as CordovaTransaction).abort('Manually Aborted');
     }
 
+    getErrorHandlerReturnValue(): boolean {
+        // react-native-sqlite-storage throws on anything but false
+        return false;
+    }
+
     protected _requiresUnicodeReplacement(): boolean {
         // TODO dadere (#333863): Possibly limit this to just iOS, since Android seems to handle it properly
         return true;

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -467,6 +467,8 @@ export abstract class SqliteSqlTransaction extends SqlTransaction {
         super(schema, verbose, maxVariables, supportsFTS3);
     }
 
+    abstract getErrorHandlerReturnValue(): boolean;    
+
     // If an external provider of the transaction determines that the transaction has failed but won't report its failures
     // (i.e. in the case of WebSQL), we need a way to kick the hanging queries that they're going to fail since otherwise
     // they'll never respond.
@@ -519,8 +521,7 @@ export abstract class SqliteSqlTransaction extends SqlTransaction {
                     console.error('SQL statement resolved twice (this time with failure)');
                 }
 
-                // Causes a rollback on websql
-                return true;
+                return this.getErrorHandlerReturnValue();
             });
         });
 

--- a/src/WebSqlProvider.ts
+++ b/src/WebSqlProvider.ts
@@ -152,4 +152,9 @@ class WebSqlTransaction extends SqlProviderBase.SqliteSqlTransaction {
         // http://stackoverflow.com/questions/16225320/websql-dont-rollback
         this.runQuery('ERROR ME TO DEATH').always(_.noop);
     }
+
+    getErrorHandlerReturnValue(): boolean {
+        // Causes a rollback on websql
+        return true;
+    }
 }


### PR DESCRIPTION
WebSql requires non-false value returned from error handler to automatically rollback transaction.
At the same time react-native-sqlite-storage would throw on anything but 'false'
This PR introduces different return values depending on the underlying implementation