### PR TITLE
Add deleteDatabase to NoSQLProvider

### DIFF
--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -38,6 +38,10 @@ export class InMemoryProvider extends NoSqlProvider.DbProvider {
         return SyncTasks.Resolved<void>();
     }
 
+    protected _deleteDatabaseInternal() {
+        return SyncTasks.Resolved();
+    }
+
     openTransaction(storeNames: string[], writeNeeded: boolean): SyncTasks.Promise<NoSqlProvider.DbTransaction> {
         return this._lockHelper!!!.openTransaction(storeNames, writeNeeded).then(token =>
             new InMemoryTransaction(this, this._lockHelper!!!, token));

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -287,6 +287,29 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
         return SyncTasks.Resolved<void>();
     }
 
+    protected _deleteDatabaseInternal(): SyncTasks.Promise<void> {
+        let trans: IDBOpenDBRequest;
+
+        const err = _.attempt(() => {
+            trans = this._dbFactory.deleteDatabase(this._dbName!!!);
+        });
+
+        if (err) {
+            return SyncTasks.Rejected(err);
+        }
+        
+        const deferred = SyncTasks.Defer<void>();
+
+        trans!!!.onsuccess = () => {
+            deferred.resolve(void 0);
+        };
+        trans!!!.onerror = (ev) => {
+            deferred.reject(ev);
+        };
+
+        return deferred.promise();
+    }
+
     openTransaction(storeNames: string[], writeNeeded: boolean): SyncTasks.Promise<NoSqlProvider.DbTransaction> {
         if (!this._db) {
             return SyncTasks.Rejected('Can\'t openTransaction, database is closed');

--- a/src/NodeSqlite3DbProvider.ts
+++ b/src/NodeSqlite3DbProvider.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * NodeSqlite3DbProvider.ts
  * Author: David de Regt
  * Copyright: Microsoft 2015
@@ -76,6 +76,10 @@ export default class NodeSqlite3DbProvider extends SqlProviderBase.SqlProviderBa
             });
             return task.promise();
         });
+    }
+
+    protected _deleteDatabaseInternal(): SyncTasks.Promise<void> {
+        return SyncTasks.Rejected<void>('No support for deleting');
     }
 }
 

--- a/src/WebSqlProvider.ts
+++ b/src/WebSqlProvider.ts
@@ -106,6 +106,10 @@ export class WebSqlProvider extends SqlProviderBase.SqlProviderBase {
         return SyncTasks.Resolved<void>();
     }
 
+    protected _deleteDatabaseInternal(): SyncTasks.Promise<void> {
+        return SyncTasks.Rejected<void>('No support for deleting');
+    }
+
     openTransaction(storeNames: string[], writeNeeded: boolean): SyncTasks.Promise<SqlProviderBase.SqlTransaction> {
         if (!this._db) {
             return SyncTasks.Rejected('Database closed');


### PR DESCRIPTION
- close the DB, then attempt to delete it
- Implementation for indexedDB
- Not implemented for Node / WebSQL
- calls the sqlitePlugin.deleteDatabase in CordovaNativeSqliteProvider
- very basic UT