### PR TITLE
Add doNotBackfill to index schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ npm run webtest
 ## Testing
 1. Compile tests
 1. Open test.html in browser
+1. You can add `?grep=foo` to the URL to run only tests containing 'foo' in the name

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -119,7 +119,11 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
         dbOpen.onupgradeneeded = (event) => {
             const db: IDBDatabase = dbOpen.result;
             const target = <IDBOpenDBRequest>(event.currentTarget || event.target);
-            const trans = target.transaction!!!;
+            const trans = target.transaction;
+
+            if (!trans) {
+                throw new Error('onupgradeneeded: target is null!');
+            }
 
             if (schema.lastUsableVersion && event.oldVersion < schema.lastUsableVersion) {
                 // Clear all stores if it's past the usable version

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -139,8 +139,8 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
             // Create all stores
             _.each(schema.stores, storeSchema => {
                 let store: IDBObjectStore;
-                let storeExistedBefore = false;
-                if (!_.includes(db.objectStoreNames, storeSchema.name)) { // store doesn't exist yet
+                const storeExistedBefore = _.includes(db.objectStoreNames, storeSchema.name);
+                if (!storeExistedBefore) { // store doesn't exist yet
                     let primaryKeyPath = storeSchema.primaryKeyPath;
                     if (this._fakeComplicatedKeys && NoSqlProviderUtils.isCompoundKeyPath(primaryKeyPath)) {
                         // Going to have to hack the compound primary key index into a column, so here it is.
@@ -150,7 +150,6 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
                     // Any is to fix a lib.d.ts issue in TS 2.0.3 - it doesn't realize that keypaths can be compound for some reason...
                     store = db.createObjectStore(storeSchema.name, { keyPath: primaryKeyPath } as any);
                 } else { // store exists, might need to update indexes and migrate the data
-                    storeExistedBefore = true;
                     store = trans.objectStore(storeSchema.name);
 
                     // Check for any indexes no longer in the schema or have been changed

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -27,6 +27,7 @@ export interface IndexSchema {
     multiEntry?: boolean;
     fullText?: boolean;
     includeDataInIndex?: boolean;
+    doNotBackfill?: boolean;
 }
 
 // Schema type describing a data store.  Must give a keypath for the primary key for the store.  Further indexes are optional.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
         "noImplicitThis": true,
         "noUnusedLocals": true,
         "forceConsistentCasingInFileNames": true,
-        "strict": true
+        "strict": true,
+        "sourceMap": true
     },
 
     "filesGlob": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,9 @@ var webpackConfig = {
             exclude: /node_modules/,
             loader: 'awesome-typescript-loader'
         }]
-    }  
+    },
+
+    mode: 'development'
 };
 
 module.exports = webpackConfig;


### PR DESCRIPTION
If we want to add a new index to any databases that already have lots of data, we must go through a full migration (pull all data out, process in JS & push back in).  In some cases we only care about the index going forward, so there's no need to rebuild the index.

Adding support to build these index tables/columns without blowing the existing data away.