### PR TITLE
Remove index without doing a full migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   },
   "devDependencies": {
     "@types/mocha": "2.2.38",
+    "@types/sinon": "^5.0.2",
     "awesome-typescript-loader": "^5.2.0",
     "mocha": "^5.2.0",
+    "sinon": "^6.3.1",
     "sqlite3": "^4.0.2",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.0.3",

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -198,6 +198,17 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                         }
                     });
 
+                    const deleteFromMeta = (metasToDelete: IndexMetadata[]) => {
+                        // Generate as many '?' as there are params
+                        let placeholder = '?';
+                        for (let i = 1; i < metasToDelete.length; i++) {
+                            placeholder += ',?';
+                        }
+
+                        return trans.runQuery('DELETE FROM metadata WHERE name IN (' + placeholder + ')',
+                            _.map(metasToDelete, meta => meta.key));
+                    };
+
                     // Check each table!
                     let dropQueries: SyncTasks.Promise<any>[] = [];
                     if (wipeAnyway || (this._schema!!!.lastUsableVersion && oldVersion < this._schema!!!.lastUsableVersion!!!)) {
@@ -209,14 +220,8 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                         dropQueries = _.map(tableNames, name => trans.runQuery('DROP TABLE ' + name));
 
                         if (indexMetadata.length > 0) {
-                            // Generate as many '?' as there are params
-                            let placeholder = '?';
-                            for (let i = 1; i < indexMetadata.length; i++) {
-                                placeholder += ',?';
-                            }
                             // Drop all existing metadata
-                            dropQueries.push(trans.runQuery('DELETE FROM metadata WHERE name IN (' + placeholder + ')',
-                                _.map(indexMetadata, meta => meta.key)));
+                            dropQueries.push(deleteFromMeta(indexMetadata));
                             indexMetadata = [];
                         }
                         tableNames = [];
@@ -239,13 +244,7 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
 
                             // Clean up metas
                             if (metasToDelete.length > 0) {
-                                // Generate as many '?' as there are params
-                                let placeholder = '?';
-                                for (let i = 1; i < metasToDelete.length; i++) {
-                                    placeholder += ',?';
-                                }
-                                transList.push(trans.runQuery('DELETE FROM metadata where name in (' + placeholder + ')',
-                                    _.map(metasToDelete, meta => meta.key)));
+                                transList.push(deleteFromMeta(metasToDelete));
                                 indexMetadata = _.filter(indexMetadata, meta => !_.includes(metaKeysToDelete, meta.key));
                             }
                             return transList;
@@ -278,9 +277,11 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                                         if (NoSqlProviderUtils.isCompoundKeyPath(index.keyPath)) {
                                             return SyncTasks.Rejected('Can\'t use multiEntry and compound keys');
                                         } else {
-                                            return trans.runQuery('CREATE TABLE ' + indexIdentifier + ' (nsp_key TEXT, nsp_refpk TEXT' +
+                                            return trans.runQuery('CREATE TABLE IF NOT EXISTS ' + indexIdentifier +
+                                                ' (nsp_key TEXT, nsp_refpk TEXT' +
                                                 (index.includeDataInIndex ? ', nsp_data TEXT' : '') + ')').then(() => {
-                                                    return trans.runQuery('CREATE ' + (index.unique ? 'UNIQUE ' : '') + 'INDEX ' +
+                                                    return trans.runQuery('CREATE ' + (index.unique ? 'UNIQUE ' : '') + 
+                                                        'INDEX IF NOT EXISTS ' +
                                                         indexIdentifier + '_pi ON ' + indexIdentifier + ' (nsp_key, nsp_refpk' +
                                                         (index.includeDataInIndex ? ', nsp_data' : '') + ')');
                                                 });
@@ -288,10 +289,11 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                                     } else if (index.fullText && this._supportsFTS3) {
                                         // If FTS3 isn't supported, we'll make a normal column and use LIKE to seek over it, so the
                                         // fallback below works fine.
-                                        return trans.runQuery('CREATE VIRTUAL TABLE ' + indexIdentifier +
+                                        return trans.runQuery('CREATE VIRTUAL TABLE IF NOT EXISTS ' + indexIdentifier +
                                             ' USING FTS3(nsp_key TEXT, nsp_refpk TEXT)');
                                     } else {
-                                        return trans.runQuery('CREATE ' + (index.unique ? 'UNIQUE ' : '') + 'INDEX ' + indexIdentifier +
+                                        return trans.runQuery('CREATE ' + (index.unique ? 'UNIQUE ' : '') +
+                                            'INDEX IF NOT EXISTS ' + indexIdentifier +
                                             ' ON ' + storeSchema.name + ' (nsp_i_' + index.name +
                                             (index.includeDataInIndex ? ', nsp_data' : '') + ')');
                                     }
@@ -306,23 +308,35 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                             fieldList.push('nsp_pk TEXT PRIMARY KEY');
                             fieldList.push('nsp_data TEXT');
 
-                            const columnBasedIndexes = _.filter(storeSchema.indexes, index =>
+                            const columnBasedIndices = _.filter(storeSchema.indexes, index =>
                                 !indexUsesSeparateTable(index, this._supportsFTS3));
-                                
-                            const indexColumns = _.map(columnBasedIndexes, index => 'nsp_i_' + index.name + ' TEXT');
+
+                            const indexColumns = _.map(columnBasedIndices, index => 'nsp_i_' + index.name + ' TEXT');
                             fieldList = fieldList.concat(indexColumns);
                             const tableMakerSql = 'CREATE TABLE ' + storeSchema.name + ' (' + fieldList.join(', ') + ')';
                             
                             const currentIndexMetas = _.filter(indexMetadata, meta => meta.storeName === storeSchema.name);
+                            
+                            // find indices in the schema that did not exist before
+                            const newIndices = _.filter(storeSchema.indexes, index => {
+                                const indexIdentifier = getIndexIdentifier(storeSchema, index);
+                                return !_.some(currentIndexMetas, meta => meta.key === indexIdentifier);
+                            });
+
+                            // find indices in the meta that do not exist in the new schema
+                            const removedIndexMetas = _.filter(currentIndexMetas, meta => 
+                                !_.some(storeSchema.indexes, newIndex => getIndexIdentifier(storeSchema, newIndex) === meta.key));
+
+                            const [removedTableIndexMetas, removedColumnIndexMetas] = _.partition(removedIndexMetas, 
+                                meta => indexUsesSeparateTable(meta.index, this._supportsFTS3));
 
                             // find new indices which don't require backfill
-                            const newNoBackfillIndices = _.filter(storeSchema.indexes, index => {
-                                const indexIdentifier = getIndexIdentifier(storeSchema, index);
-                                return !!index.doNotBackfill && !_.some(currentIndexMetas, meta => meta.key === indexIdentifier);
+                            const newNoBackfillIndices = _.filter(newIndices, index => {
+                                return !!index.doNotBackfill;
                             });
 
                             // columns requiring no backfill could be simply added to the table
-                            const newIndexColumnsNoBackfill = _.intersection(newNoBackfillIndices, columnBasedIndexes);
+                            const newIndexColumnsNoBackfill = _.intersection(newNoBackfillIndices, columnBasedIndices);
 
                             const columnAdder = () => {
                                 const addQueries = _.map(newIndexColumnsNoBackfill, index => 
@@ -338,14 +352,7 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                                     .then(() => indexMaker(storeSchema.indexes));
                             };
 
-                            const needsDataMigration = () => {
-                                //  If some indices have been removed - migration is needed
-                                const areIndicesRemoved = _.some(currentIndexMetas, meta => 
-                                    !_.some(storeSchema.indexes, newIndex => getIndexIdentifier(storeSchema, newIndex) === meta.key));
-                                if (areIndicesRemoved) {
-                                    return true;
-                                }
-
+                            const needsFullMigration = () => {
                                 // Check all the indices in the schema
                                 return _.some(storeSchema.indexes, index => {
                                     const indexIdentifier = getIndexIdentifier(storeSchema, index);
@@ -381,44 +388,104 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                                 });
                             };
 
-                            // If the table exists, check if we can view the sql statement used to create this table. Use it to determine
-                            // if a migration is needed, otherwise just make a copy and fully migrate the data over.
+                            const dropColumnIndices = () => {
+                                return _.map(indexNames[storeSchema.name], indexName =>
+                                    trans.runQuery('DROP INDEX ' + indexName));
+                            };
+
+                            const dropIndexTables = (tableNames: string[]) => {
+                                return _.map(tableNames, tableName => 
+                                    trans.runQuery('DROP TABLE IF EXISTS ' + storeSchema.name + '_' + tableName)
+                                );
+                            };
+
+                            const createTempTable = () => {
+                                // Then rename the table to a temp_[name] table so we can migrate the data out of it
+                                return trans.runQuery('ALTER TABLE ' + storeSchema.name + ' RENAME TO temp_' + storeSchema.name);
+                            };
+
+                            const dropTempTable = () => {
+                                return trans.runQuery('DROP TABLE temp_' + storeSchema.name);
+                            };
+
+                            // If the table exists, check if we can to determine if a migration is needed
+                            // If a full migration is needed, we have to copy all the data over and re-populate indices
+                            // If a in-place migration is enough, we can just copy the data
+                            // If no migration is needed, we can just add new column for new indices
                             const tableExists = _.includes(tableNames, storeSchema.name);
-                            const tableRequiresMigration = tableExists && needsDataMigration();
+                            const doFullMigration = tableExists && needsFullMigration();
+                            const doSqlInPlaceMigration = tableExists && !doFullMigration && removedColumnIndexMetas.length > 0;
+                            const adddNewColumns = tableExists && !doSqlInPlaceMigration && newNoBackfillIndices.length > 0;
 
-                            if (tableExists && tableRequiresMigration) {
+                            if (!tableExists) {
+                                // Table doesn't exist -- just go ahead and create it without the migration path
+                                tableQueries.push(tableMaker());
+                            } else if (doFullMigration) {
                                 // Nuke old indexes on the original table (since they don't change names and we don't need them anymore).
-                                // Also new old multientry/FTS tables (if they still exist after the purge above.)
-                                let indexDroppers: SyncTasks.Promise<any[]>[] = _.map(indexNames[storeSchema.name], indexName =>
-                                    trans.runQuery('DROP INDEX ' + indexName)).concat(_.map(indexTables[storeSchema.name], tableName =>
-                                    trans.runQuery('DROP TABLE IF EXISTS ' + storeSchema.name + '_' + tableName)));
+                                // Also nuke no longer needed old multientry/FTS tables
+                                const indexDroppers: SyncTasks.Promise<any[]>[] = _.concat(
+                                    dropColumnIndices(), 
+                                    dropIndexTables(indexTables[storeSchema.name])
+                                );
 
-                                let nukeIndexesAndRename = SyncTasks.all(indexDroppers).then(() => {
-                                    // Then rename the table to a temp_[name] table so we can migrate the data out of it
-                                    return trans.runQuery('ALTER TABLE ' + storeSchema.name + ' RENAME TO temp_' + storeSchema.name);
-                                });
+                                if (removedIndexMetas.length > 0) {
+                                    indexDroppers.push(deleteFromMeta(removedIndexMetas));
+                                }
 
                                 // Migrate the data over using our existing put functions
                                 // (since it will do the right things with the indexes)
                                 // and delete the temp table.
-                                let migrator = () => {
+                                const jsMigrator = () => {
                                     let store = trans.getStore(storeSchema.name);
                                     return trans.internal_getResultsFromQuery('SELECT nsp_data FROM temp_' + storeSchema.name)
                                     .then(objs => {
-                                        return store.put(objs).then(() => {
-                                            return trans.runQuery('DROP TABLE temp_' + storeSchema.name);
-                                        });
+                                        return store.put(objs);
                                     });
                                 };
 
-                                tableQueries.push(nukeIndexesAndRename.then(tableMaker).then(migrator));
-                            } else if (tableExists && newNoBackfillIndices.length > 0) {
-                                // we can add new indices without migrating
-                                tableQueries.push(columnAdder().then(() => indexMaker(newNoBackfillIndices)));
-                            } else if (!tableExists) {
-                                // Table doesn't exist -- just go ahead and create it without the migration path
-                                tableQueries.push(tableMaker());
+                                tableQueries.push(
+                                    SyncTasks.all(indexDroppers)
+                                        .then(createTempTable)
+                                        .then(tableMaker)
+                                        .then(jsMigrator)
+                                        .then(dropTempTable)
+                                );
+                            } else if (doSqlInPlaceMigration) {
+                                  
+                                const sqlInPlaceMigrator = () => {
+                                    return trans.runQuery('INSERT INTO ' + storeSchema.name +
+                                        ' SELECT ' + ['nsp_pk', 'nsp_data', ...indexColumns].join(', ') + 
+                                        ' FROM temp_' + storeSchema.name);
+
+                                };
+
+                                const indexDroppers = 
+                                    dropIndexTables(removedTableIndexMetas.map(meta => getIndexIdentifier(storeSchema, meta.index)));
+                                if (removedIndexMetas.length > 0) {
+                                    indexDroppers.push(deleteFromMeta(removedIndexMetas));
+                                }
+
+                                tableQueries.push(
+                                    SyncTasks.all(indexDroppers)
+                                    .then(createTempTable)
+                                    .then(tableMaker)
+                                    .then(sqlInPlaceMigrator)
+                                    .then(dropTempTable)
+                                );
+
+                            } else if (adddNewColumns) {
+                                const indexDroppers = 
+                                    dropIndexTables(removedTableIndexMetas.map(meta => getIndexIdentifier(storeSchema, meta.index)));
+                                if (removedIndexMetas.length > 0) {
+                                    indexDroppers.push(deleteFromMeta(removedIndexMetas));
+                                }
+
+                                tableQueries.push(
+                                    SyncTasks.all(indexDroppers)
+                                    .then(columnAdder)
+                                    .then(() => indexMaker(newNoBackfillIndices)));
                             }
+
                         });
 
                         return SyncTasks.all(tableQueries);

--- a/src/WebSqlProvider.ts
+++ b/src/WebSqlProvider.ts
@@ -98,7 +98,7 @@ export class WebSqlProvider extends SqlProviderBase.SqlProviderBase {
                 });
             }, (err) => {
                 deferred.reject(err.message + (errorDetail ? ', Detail: ' + errorDetail : ''));
-            }, );
+            });
         } else {
             deferred.resolve(void 0);
         }

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -2057,6 +2057,7 @@ describe('NoSqlProvider', function () {
                         });
 
                         it('Removes index without pulling data to JS', () => {
+                            let storeSpy: sinon.SinonSpy|undefined;
                             return openProvider(provName, {
                                 version: 1,
                                 stores: [
@@ -2076,8 +2077,8 @@ describe('NoSqlProvider', function () {
                                     return prov.close();
                                 });
                             }).then(() => {
-                            const storeSpy = sinon.spy(SqlTransaction.prototype, 'getStore');
-                            return openProvider(provName, {
+                                storeSpy = sinon.spy(SqlTransaction.prototype, 'getStore');
+                                return openProvider(provName, {
                                     version: 2,
                                     stores: [
                                         {
@@ -2085,9 +2086,10 @@ describe('NoSqlProvider', function () {
                                             primaryKeyPath: 'id'
                                         }
                                     ]
-                                }, false).then(prov => {
+                                }, false)
+                                .then(prov => {
                                     // NOTE - the line below tests an implementation detail
-                                    sinon.assert.notCalled(storeSpy);
+                                    sinon.assert.notCalled(storeSpy!!!);
 
                                     // check the index was actually removed
                                     const p1 = prov.get('test', 'abc').then((item: any) => {
@@ -2105,10 +2107,12 @@ describe('NoSqlProvider', function () {
                                     });
                                     return SyncTasks.all([p1, p2]).then(() => {
                                         return prov.close();
-                                    }).always(() => {
-                                        storeSpy.restore();
                                     });
                                 });
+                            }).always(() => {
+                                if (storeSpy) {
+                                    storeSpy.restore();
+                                }
                             });
                         });
 
@@ -2150,7 +2154,7 @@ describe('NoSqlProvider', function () {
                                             });
                                         });
                                     });
-                                    return SyncTasks.all([p1]).then(() => {
+                                    return p1.then(() => {
                                         return prov.close();
                                     });
                                 });

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -2109,7 +2109,7 @@ describe('NoSqlProvider', function () {
                                         return prov.close();
                                     });
                                 });
-                            }).always(() => {
+                            }).finally(() => {
                                 if (storeSpy) {
                                     storeSpy.restore();
                                 }
@@ -2144,7 +2144,7 @@ describe('NoSqlProvider', function () {
                                     ]
                                 }, false)
                                 .then(prov => {
-                                    const p1 = prov.openTransaction(undefined, false).then(trans => {
+                                    return prov.openTransaction(undefined, false).then(trans => {
                                         return (trans as SqlTransaction).runQuery('SELECT name, value from metadata').then(fullMeta => {
                                             _.each(fullMeta, (meta: any) => {
                                                 let metaObj = JSON.parse(meta.value);
@@ -2153,8 +2153,7 @@ describe('NoSqlProvider', function () {
                                                 }
                                             });
                                         });
-                                    });
-                                    return p1.then(() => {
+                                    }).then(() => {
                                         return prov.close();
                                     });
                                 });

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -1,5 +1,6 @@
 import assert = require('assert');
 import _ = require('lodash');
+import sinon = require('sinon');
 import SyncTasks = require('synctasks');
 
 import NoSqlProvider = require('../NoSqlProvider');
@@ -11,6 +12,8 @@ import { IndexedDbProvider } from '../IndexedDbProvider';
 import { WebSqlProvider } from '../WebSqlProvider';
 
 import NoSqlProviderUtils = require('../NoSqlProviderUtils');
+
+import { SqlTransaction } from '../SqlProviderBase';
 
 // Don't trap exceptions so we immediately see them with a stack trace
 SyncTasks.config.catchExceptions = false;
@@ -2047,6 +2050,107 @@ describe('NoSqlProvider', function () {
                                         assert.equal(items.length, 0);
                                     });
                                     return SyncTasks.all([p1, p2, p3, p4]).then(() => {
+                                        return prov.close();
+                                    });
+                                });
+                            });
+                        });
+
+                        it('Removes index without pulling data to JS', () => {
+                            return openProvider(provName, {
+                                version: 1,
+                                stores: [
+                                    {
+                                        name: 'test',
+                                        primaryKeyPath: 'id',
+                                        indexes: [
+                                            {
+                                                name: 'ind1',
+                                                keyPath: 'content',
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }, true).then(prov => {
+                                return prov.put('test', { id: 'abc', content: 'ghi' }).then(() => {
+                                    return prov.close();
+                                });
+                            }).then(() => {
+                            const storeSpy = sinon.spy(SqlTransaction.prototype, 'getStore');
+                            return openProvider(provName, {
+                                    version: 2,
+                                    stores: [
+                                        {
+                                            name: 'test',
+                                            primaryKeyPath: 'id'
+                                        }
+                                    ]
+                                }, false).then(prov => {
+                                    // NOTE - the line below tests an implementation detail
+                                    sinon.assert.notCalled(storeSpy);
+
+                                    // check the index was actually removed
+                                    const p1 = prov.get('test', 'abc').then((item: any) => {
+                                        assert.ok(item);
+                                        assert.equal(item.id, 'abc');
+                                        assert.equal(item.content, 'ghi');
+                                    });
+                                    const p2 = prov.getOnly('test', 'ind1', 'ghi').then((items: any[]) => {
+                                        assert.equal(items.length, 1);
+                                        assert.equal(items[0].id, 'abc');
+                                    }).then(() => {
+                                        assert.ok(false, 'should not work');
+                                    }, err => {
+                                        return SyncTasks.Resolved();
+                                    });
+                                    return SyncTasks.all([p1, p2]).then(() => {
+                                        return prov.close();
+                                    }).always(() => {
+                                        storeSpy.restore();
+                                    });
+                                });
+                            });
+                        });
+
+                        it('Cleans up stale indices from metadata', () => {
+                            return openProvider(provName, {
+                                version: 1,
+                                stores: [
+                                    {
+                                        name: 'test',
+                                        primaryKeyPath: 'id',
+                                        indexes: [
+                                            {
+                                                name: 'ind1',
+                                                keyPath: 'content',
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }, true)
+                            .then(prov =>  prov.close())
+                            .then(() => {
+                                return openProvider(provName, {
+                                    version: 2,
+                                    stores: [
+                                        {
+                                            name: 'test',
+                                            primaryKeyPath: 'id'
+                                        }
+                                    ]
+                                }, false)
+                                .then(prov => {
+                                    const p1 = prov.openTransaction(undefined, false).then(trans => {
+                                        return (trans as SqlTransaction).runQuery('SELECT name, value from metadata').then(fullMeta => {
+                                            _.each(fullMeta, (meta: any) => {
+                                                let metaObj = JSON.parse(meta.value);
+                                                if (metaObj.storeName === 'test' && !!metaObj.index && metaObj.index.name === 'ind1') {
+                                                    assert.fail('Removed index should not exist in the meta!');
+                                                }
+                                            });
+                                        });
+                                    });
+                                    return SyncTasks.all([p1]).then(() => {
                                         return prov.close();
                                     });
                                 });


### PR DESCRIPTION
If the new schema removes an index, we don't need to do a full wipe and data migration in JS, we can simply remove the index tables / columns.
However, since sqlite does not have a 'Remove column' query, instead we create a new table with less columns and copy the data over in a singe SQL statement.

Also added cleanup of metadata for removed indices + UT.