### PR TITLE
Enable batched upgrades in SQL providers. Aim to pull 1MB of data out…

### DIFF
--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -35,6 +35,8 @@ export interface StoreSchema {
     name: string;
     indexes?: IndexSchema[];
     primaryKeyPath: KeyPathType;
+    // Estimated object size to enable batched data migration. Default = 200
+    estimatedObjBytes?: number;
 }
 
 // Schema representing a whole database (a collection of stores).  Change your version number whenever you change your schema or

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -439,7 +439,7 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                                 // and delete the temp table.
                                 const jsMigrator = (batchOffset = 0): SyncTasks.Promise<any> => {
                                     let esimatedSize = storeSchema.estimatedObjBytes || DB_SIZE_ESIMATE_DEFAULT;
-                                    let batchSize = Math.floor(DB_MIGRATION_MAX_BYTE_TARGET / esimatedSize);
+                                    let batchSize = Math.max(1, Math.floor(DB_MIGRATION_MAX_BYTE_TARGET / esimatedSize));
                                     let store = trans.getStore(storeSchema.name);
                                     return trans.internal_getResultsFromQuery('SELECT nsp_data FROM temp_' + storeSchema.name + ' LIMIT ' +
                                             batchSize + ' OFFSET ' + batchOffset)

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -447,14 +447,12 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                                             return store.put(objs).then(() => {
                                                 // Are we done migrating?
                                                 if (objs.length < batchSize) {
-                                                    return trans.runQuery('DROP TABLE temp_' + storeSchema.name);
+                                                    return undefined;
                                                 }
-                                                return migrator(batchOffset + batchSize);
+                                                return jsMigrator(batchOffset + batchSize);
                                             });
                                     });
                                 };
-
-
 
                                 tableQueries.push(
                                     SyncTasks.all([
@@ -463,7 +461,9 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                                     ])
                                     .then(createTempTable)
                                     .then(tableMaker)
-                                    .then(jsMigrator)
+                                    .then(() => {
+                                        return jsMigrator();
+                                    })
                                     .then(dropTempTable)
                                 );
                             } 

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -43,6 +43,9 @@ const schemaVersionKey = 'schemaVersion';
 // This was taked from the sqlite documentation
 const SQLITE_MAX_SQL_LENGTH_IN_BYTES = 1000000;
 
+const DB_SIZE_ESIMATE_DEFAULT = 200;
+const DB_MIGRATION_MAX_BYTE_TARGET = 1000000;
+
 interface IndexMetadata {
     key: string;
     storeName: string;
@@ -434,13 +437,24 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                                 // Migrate the data over using our existing put functions
                                 // (since it will do the right things with the indexes)
                                 // and delete the temp table.
-                                const jsMigrator = () => {
+                                const jsMigrator = (batchOffset = 0): SyncTasks.Promise<any> => {
+                                    let esimatedSize = storeSchema.estimatedObjBytes || DB_SIZE_ESIMATE_DEFAULT;
+                                    let batchSize = Math.floor(DB_MIGRATION_MAX_BYTE_TARGET / esimatedSize);
                                     let store = trans.getStore(storeSchema.name);
-                                    return trans.internal_getResultsFromQuery('SELECT nsp_data FROM temp_' + storeSchema.name)
-                                    .then(objs => {
-                                        return store.put(objs);
+                                    return trans.internal_getResultsFromQuery('SELECT nsp_data FROM temp_' + storeSchema.name + ' LIMIT ' +
+                                            batchSize + ' OFFSET ' + batchOffset)
+                                        .then(objs => {
+                                            return store.put(objs).then(() => {
+                                                // Are we done migrating?
+                                                if (objs.length < batchSize) {
+                                                    return trans.runQuery('DROP TABLE temp_' + storeSchema.name);
+                                                }
+                                                return migrator(batchOffset + batchSize);
+                                            });
                                     });
                                 };
+
+
 
                                 tableQueries.push(
                                     SyncTasks.all([

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -1244,7 +1244,7 @@ describe('NoSqlProvider', function () {
                                 ]
                             }, false).then(prov => {
                                 if (transactionSpy) {
-                                    assert.ok(transactionSpy.callCount === expectedCallCount);
+                                    assert.equal(transactionSpy.callCount, expectedCallCount);
                                     transactionSpy.restore();
                                 }
                                 return prov.getAll('test', undefined).then((records: any) => {


### PR DESCRIPTION
… of the DB at a time to avoid potential OOM conditions when upgrading large databases

Allow consumers of NoSqlProvider to provide an estimated size for their database objects. This will help do better batching without having to do an initial transaction to see what object sizes look like