### PR TITLE
Properly drop old indices on migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosqlprovider",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "description": "A cross-browser/platform indexeddb-like client library",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {


### PR DESCRIPTION
- Drop indices when doing fast sql migration
- Add indexFixer if we got into a bad state