### PR TITLE
Optimize multi-index and FTS index insert/update on SQL Providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosqlprovider",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "A cross-browser/platform indexeddb-like client library",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {


### PR DESCRIPTION
We can do the insert and deletes of multi-key indexes in one pass instead of executing multiple queries