### PR TITLE
Add a flag to NoSqlProvider to skip ordering results. This can make th…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nosqlprovider",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "description": "A cross-browser/platform indexeddb-like client library",
   "author": "David de Regt <David.de.Regt@microsoft.com>",
   "scripts": {

--- a/src/FullTextSearchHelpers.ts
+++ b/src/FullTextSearchHelpers.ts
@@ -91,10 +91,12 @@ export abstract class DbIndexFTSFromRangeQueries implements NoSqlProvider.DbInde
         });
     }
 
-    abstract getAll(reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]>;
-    abstract getOnly(key: KeyType, reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]>;
+    abstract getAll(reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number)
+        : SyncTasks.Promise<ItemType[]>;
+    abstract getOnly(key: KeyType, reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number)
+        : SyncTasks.Promise<ItemType[]>;
     abstract getRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
-        reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]>;
+        reverseOrSortOrder?: boolean|NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]>;
     abstract countAll(): SyncTasks.Promise<number>;
     abstract countOnly(key: KeyType): SyncTasks.Promise<number>;
     abstract countRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -303,7 +303,7 @@ class InMemoryIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
         return data;
     }
 
-    getAll(reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
+    getAll(reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
         if (!this._trans.internal_isOpen()) {
             return SyncTasks.Rejected('InMemoryTransaction already closed');
         }
@@ -316,15 +316,16 @@ class InMemoryIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
         }
 
         const sortedKeys = _.keys(data).sort();
-        return this._returnResultsFromKeys(data, sortedKeys, reverse, limit, offset);
+        return this._returnResultsFromKeys(data, sortedKeys, reverseOrSortOrder, limit, offset);
     }
 
-    getOnly(key: KeyType, reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
-        return this.getRange(key, key, false, false, reverse, limit, offset);
+    getOnly(key: KeyType, reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number)
+            : SyncTasks.Promise<ItemType[]> {
+        return this.getRange(key, key, false, false, reverseOrSortOrder, limit, offset);
     }
 
     getRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
-            reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
+            reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
         if (!this._trans.internal_isOpen()) {
             return SyncTasks.Rejected('InMemoryTransaction already closed');
         }
@@ -339,7 +340,7 @@ class InMemoryIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
             return SyncTasks.Rejected(err);
         }
 
-        return this._returnResultsFromKeys(data!!!, sortedKeys!!!, reverse, limit, offset);
+        return this._returnResultsFromKeys(data!!!, sortedKeys!!!, reverseOrSortOrder, limit, offset);
     }
 
     // Warning: This function can throw, make sure to trap.
@@ -351,9 +352,9 @@ class InMemoryIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
             (key > keyLow || (key === keyLow && !lowRangeExclusive)) && (key < keyHigh || (key === keyHigh && !highRangeExclusive)));
     }
 
-    private _returnResultsFromKeys(data: _.Dictionary<ItemType[]>|_.Dictionary<ItemType>, sortedKeys: string[], reverse?: boolean,
-            limit?: number, offset?: number) {
-        if (reverse) {
+    private _returnResultsFromKeys(data: _.Dictionary<ItemType[]> | _.Dictionary<ItemType>, sortedKeys: string[],
+            reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number) {
+        if (reverseOrSortOrder === true || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse) {
             sortedKeys = _.reverse(sortedKeys);
         }
 

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -720,22 +720,24 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
         }
     }
 
-    getAll(reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
+    getAll(reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
         // ************************* Don't change this null to undefined, IE chokes on it... *****************************
         // ************************* Don't change this null to undefined, IE chokes on it... *****************************
         // ************************* Don't change this null to undefined, IE chokes on it... *****************************
+        const reverse = reverseOrSortOrder === false || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
         const req = this._store.openCursor(null!!!, reverse ? 'prev' : 'next');
         return this._resolveCursorResult(req, limit, offset);
     }
 
-    getOnly(key: KeyType, reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
+    getOnly(key: KeyType, reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number)
+            : SyncTasks.Promise<ItemType[]> {
         const keyRange = _.attempt(() => {
             return this._getKeyRangeForOnly(key);
         });
         if (_.isError(keyRange)) {
             return SyncTasks.Rejected(keyRange);
         }
-
+        const reverse = reverseOrSortOrder === false || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
         const req = this._store.openCursor(keyRange, reverse ? 'prev' : 'next');
         return this._resolveCursorResult(req, limit, offset);
     }
@@ -749,7 +751,7 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
     }
 
     getRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
-            reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
+            reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
         const keyRange = _.attempt(() => {
             return this._getKeyRangeForRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
         });
@@ -757,6 +759,7 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
             return SyncTasks.Rejected(keyRange);
         }
 
+        const reverse = reverseOrSortOrder === false || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
         const req = this._store.openCursor(keyRange, reverse ? 'prev' : 'next');
         return this._resolveCursorResult(req, limit, offset);
     }

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -721,10 +721,10 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
     }
 
     getAll(reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
-        // ************************* Don't change this null to undefined, IE chokes on it... *****************************
-        // ************************* Don't change this null to undefined, IE chokes on it... *****************************
-        // ************************* Don't change this null to undefined, IE chokes on it... *****************************
         const reverse = reverseOrSortOrder === true || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
+        // ************************* Don't change this null to undefined, IE chokes on it... *****************************
+        // ************************* Don't change this null to undefined, IE chokes on it... *****************************
+        // ************************* Don't change this null to undefined, IE chokes on it... *****************************
         const req = this._store.openCursor(null!!!, reverse ? 'prev' : 'next');
         return this._resolveCursorResult(req, limit, offset);
     }

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -724,7 +724,7 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
         // ************************* Don't change this null to undefined, IE chokes on it... *****************************
         // ************************* Don't change this null to undefined, IE chokes on it... *****************************
         // ************************* Don't change this null to undefined, IE chokes on it... *****************************
-        const reverse = reverseOrSortOrder === false || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
+        const reverse = reverseOrSortOrder === true || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
         const req = this._store.openCursor(null!!!, reverse ? 'prev' : 'next');
         return this._resolveCursorResult(req, limit, offset);
     }
@@ -737,7 +737,7 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
         if (_.isError(keyRange)) {
             return SyncTasks.Rejected(keyRange);
         }
-        const reverse = reverseOrSortOrder === false || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
+        const reverse = reverseOrSortOrder === true || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
         const req = this._store.openCursor(keyRange, reverse ? 'prev' : 'next');
         return this._resolveCursorResult(req, limit, offset);
     }
@@ -759,7 +759,7 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
             return SyncTasks.Rejected(keyRange);
         }
 
-        const reverse = reverseOrSortOrder === false || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
+        const reverse = reverseOrSortOrder === true || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
         const req = this._store.openCursor(keyRange, reverse ? 'prev' : 'next');
         return this._resolveCursorResult(req, limit, offset);
     }

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -17,7 +17,12 @@ import SyncTasks = require('synctasks');
 export type ItemType = object;
 export type KeyComponentType = string|number|Date;
 export type KeyType = KeyComponentType|KeyComponentType[];
-export type KeyPathType = string|string[];
+export type KeyPathType = string | string[];
+export enum QuerySortOrder {
+    None,
+    Forward,
+    Reverse
+}
 
 // Schema type describing an index for a store.
 export interface IndexSchema {
@@ -55,10 +60,10 @@ export enum FullTextTermResolution {
 
 // Interface type describing an index being opened for querying.
 export interface DbIndex {
-    getAll(reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]>;
-    getOnly(key: KeyType, reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]>;
+    getAll(reverseOrSortOrder?: boolean|QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]>;
+    getOnly(key: KeyType, reverseOrSortOrder?: boolean|QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]>;
     getRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
-        reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]>;
+        reverseOrSortOrder?: boolean|QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]>;
     countAll(): SyncTasks.Promise<number>;
     countOnly(key: KeyType): SyncTasks.Promise<number>;
     countRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
@@ -189,25 +194,25 @@ export abstract class DbProvider {
         });
     }
 
-    getAll(storeName: string, indexName: string|undefined, reverse?: boolean, limit?: number, offset?: number)
+    getAll(storeName: string, indexName: string|undefined, reverseOrSortOrder?: boolean|QuerySortOrder, limit?: number, offset?: number)
             : SyncTasks.Promise<ItemType[]> {
         return this._getStoreIndexTransaction(storeName, false, indexName).then(index => {
-            return index.getAll(reverse, limit, offset);
+            return index.getAll(reverseOrSortOrder, limit, offset);
         });
     }
 
-    getOnly(storeName: string, indexName: string|undefined, key: KeyType, reverse?: boolean, limit?: number, offset?: number)
-            : SyncTasks.Promise<ItemType[]> {
+    getOnly(storeName: string, indexName: string | undefined, key: KeyType, reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number,
+            offset?: number): SyncTasks.Promise<ItemType[]> {
         return this._getStoreIndexTransaction(storeName, false, indexName).then(index => {
-            return index.getOnly(key, reverse, limit, offset);
+            return index.getOnly(key, reverseOrSortOrder, limit, offset);
         });
     }
 
-    getRange(storeName: string, indexName: string|undefined, keyLowRange: KeyType, keyHighRange: KeyType,
-        lowRangeExclusive?: boolean, highRangeExclusive?: boolean, reverse?: boolean, limit?: number, offset?: number)
+    getRange(storeName: string, indexName: string | undefined, keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean,
+            highRangeExclusive?: boolean, reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number)
             : SyncTasks.Promise<ItemType[]> {
         return this._getStoreIndexTransaction(storeName, false, indexName).then(index => {
-            return index.getRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive, reverse, limit, offset);
+            return index.getRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive, reverseOrSortOrder, limit, offset);
         });
     }
 

--- a/src/StoreHelpers.ts
+++ b/src/StoreHelpers.ts
@@ -26,21 +26,21 @@ export class SimpleTransactionIndexHelper<ObjectType extends ItemType, IndexKeyF
         // Nothing to see here
     }
 
-    getAll(reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
-        let promise = this._index.getAll(reverse, limit, offset) as SyncTasks.Promise<ObjectType[]>;
+    getAll(reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
+        let promise = this._index.getAll(reverseOrSortOrder, limit, offset) as SyncTasks.Promise<ObjectType[]>;
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
     }
 
-    getOnly(key: IndexKeyFormat, reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
-        let promise = this._index.getOnly(key, reverse, limit, offset) as SyncTasks.Promise<ObjectType[]>;
-        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
-    }
-
-    getRange(keyLowRange: IndexKeyFormat, keyHighRange: IndexKeyFormat,
-            lowRangeExclusive?: boolean, highRangeExclusive?: boolean, reverse?: boolean, limit?: number, offset?: number)
+    getOnly(key: IndexKeyFormat, reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number)
             : SyncTasks.Promise<ObjectType[]> {
+        let promise = this._index.getOnly(key, reverseOrSortOrder, limit, offset) as SyncTasks.Promise<ObjectType[]>;
+        return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
+    }
+
+    getRange(keyLowRange: IndexKeyFormat, keyHighRange: IndexKeyFormat, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
+        reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
         let promise = this._index.getRange(keyLowRange, keyHighRange, lowRangeExclusive,
-            highRangeExclusive, reverse, limit, offset) as SyncTasks.Promise<ObjectType[]>;
+            highRangeExclusive, reverseOrSortOrder, limit, offset) as SyncTasks.Promise<ObjectType[]>;
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
     }
 
@@ -84,16 +84,16 @@ export class SimpleTransactionStoreHelper<StoreName extends string, ObjectType e
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
     }
 
-    getOnly(key: KeyFormat, reverse?: boolean, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
-        let promise = this._store.openPrimaryKey().getOnly(key, reverse, limit, offset) as SyncTasks.Promise<ObjectType[]>;
+    getOnly(key: KeyFormat, reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number)
+            : SyncTasks.Promise<ObjectType[]> {
+        let promise = this._store.openPrimaryKey().getOnly(key, reverseOrSortOrder, limit, offset) as SyncTasks.Promise<ObjectType[]>;
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
     }
 
-    getRange(keyLowRange: KeyFormat, keyHighRange: KeyFormat,
-            lowRangeExclusive?: boolean, highRangeExclusive?: boolean, reverse?: boolean, limit?: number, offset?: number)
-            : SyncTasks.Promise<ObjectType[]> {
+    getRange(keyLowRange: KeyFormat, keyHighRange: KeyFormat, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
+            reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
         let promise = this._store.openPrimaryKey().getRange(keyLowRange, keyHighRange,
-            lowRangeExclusive, highRangeExclusive, reverse, limit, offset) as SyncTasks.Promise<ObjectType[]>;
+            lowRangeExclusive, highRangeExclusive, reverseOrSortOrder, limit, offset) as SyncTasks.Promise<ObjectType[]>;
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
     }
 

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -277,14 +277,22 @@ describe('NoSqlProvider', function () {
                                 [2].forEach(v => { assert(_.find(ret, r => r.val === 'val' + v)); });
                             });
 
-                        let t3b2 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false, true, 1)
+                        let t3b2 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false, false, 1)
                             .then(retVal => {
                                 const ret = retVal as TestObj[];
-                                assert.equal(ret.length, 1, 'getRange++ lim1 rev');
-                                [4].forEach(v => { assert(_.find(ret, r => r.val === 'val' + v)); });
+                                assert.equal(ret.length, 1, 'getRange++ lim1');
+                                [2].forEach(v => { assert(_.find(ret, r => r.val === 'val' + v)); });
                             });
 
-                        let t3b3 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false,
+                        let t3b3 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false, 
+                                NoSqlProvider.QuerySortOrder.Forward, 1)
+                            .then(retVal => {
+                                const ret = retVal as TestObj[];
+                                assert.equal(ret.length, 1, 'getRange++ lim1');
+                                [2].forEach(v => { assert(_.find(ret, r => r.val === 'val' + v)); });
+                            });
+
+                        let t3b4 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false,
                                 NoSqlProvider.QuerySortOrder.Reverse, 1)
                             .then(retVal => {
                                 const ret = retVal as TestObj[];
@@ -306,7 +314,15 @@ describe('NoSqlProvider', function () {
                                 [3, 4].forEach(v => { assert(_.find(ret, r => r.val === 'val' + v)); });
                             });
 
-                        let t3d2 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false, true, 2, 1)
+                        let t3d2 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false, 
+                                NoSqlProvider.QuerySortOrder.Forward, 2, 1)
+                            .then(retVal => {
+                                const ret = retVal as TestObj[];
+                                assert.equal(ret.length, 2, 'getRange++ lim2 off1');
+                                [3, 4].forEach(v => { assert(_.find(ret, r => r.val === 'val' + v)); });
+                            });
+
+                        let t3d3 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false, true, 2, 1)
                             .then(retVal => {
                                 const ret = retVal as TestObj[];
                                 assert.equal(ret.length, 2, 'getRange++ lim2 off1 rev');
@@ -314,7 +330,7 @@ describe('NoSqlProvider', function () {
                                 [2, 3].forEach(v => { assert(_.find(ret, r => r.val === 'val' + v)); });
                             });
                         
-                        let t3d3 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false,
+                        let t3d4 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false,
                                 NoSqlProvider.QuerySortOrder.Reverse, 2, 1)
                             .then(retVal => {
                                 const ret = retVal as TestObj[];
@@ -353,8 +369,8 @@ describe('NoSqlProvider', function () {
                             assert.equal(ret, 1, 'countRange--');
                         });
 
-                        return SyncTasks.all([t1, t1count, t1b, t1c, t2, t2count, t3, t3count, t3b, t3b2, t3b3, t3c, t3d, t3d2, t3d3, t4,
-                            t4count, t5, t5count, t6, t6count]).then(() => {
+                        return SyncTasks.all([t1, t1count, t1b, t1c, t2, t2count, t3, t3count, t3b, t3b2, t3b3, t3b4, t3c, t3d, t3d2, t3d3,
+                            t3d4, t4, t4count, t5, t5count, t6, t6count]).then(() => {
                             if (compound) {
                                 let tt1 = prov.getRange('test', indexName, formIndex(2, 2), formIndex(4, 3))
                                     .then(retVal => {

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -284,6 +284,14 @@ describe('NoSqlProvider', function () {
                                 [4].forEach(v => { assert(_.find(ret, r => r.val === 'val' + v)); });
                             });
 
+                        let t3b3 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false,
+                                NoSqlProvider.QuerySortOrder.Reverse, 1)
+                            .then(retVal => {
+                                const ret = retVal as TestObj[];
+                                assert.equal(ret.length, 1, 'getRange++ lim1 rev');
+                                [4].forEach(v => { assert(_.find(ret, r => r.val === 'val' + v)); });
+                            });
+
                         let t3c = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false, false, 1, 1)
                             .then(retVal => {
                                 const ret = retVal as TestObj[];
@@ -299,6 +307,15 @@ describe('NoSqlProvider', function () {
                             });
 
                         let t3d2 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false, true, 2, 1)
+                            .then(retVal => {
+                                const ret = retVal as TestObj[];
+                                assert.equal(ret.length, 2, 'getRange++ lim2 off1 rev');
+                                assert.equal((ret[0] as TestObj).val, 'val3');
+                                [2, 3].forEach(v => { assert(_.find(ret, r => r.val === 'val' + v)); });
+                            });
+                        
+                        let t3d3 = prov.getRange('test', indexName, formIndex(2), formIndex(4), false, false,
+                                NoSqlProvider.QuerySortOrder.Reverse, 2, 1)
                             .then(retVal => {
                                 const ret = retVal as TestObj[];
                                 assert.equal(ret.length, 2, 'getRange++ lim2 off1 rev');
@@ -336,8 +353,8 @@ describe('NoSqlProvider', function () {
                             assert.equal(ret, 1, 'countRange--');
                         });
 
-                        return SyncTasks.all([t1, t1count, t1b, t1c, t2, t2count, t3, t3count, t3b, t3b2, t3c, t3d, t3d2, t4, t4count, t5,
-                                t5count, t6, t6count]).then(() => {
+                        return SyncTasks.all([t1, t1count, t1b, t1c, t2, t2count, t3, t3count, t3b, t3b2, t3b3, t3c, t3d, t3d2, t3d3, t4,
+                            t4count, t5, t5count, t6, t6count]).then(() => {
                             if (compound) {
                                 let tt1 = prov.getRange('test', indexName, formIndex(2, 2), formIndex(4, 3))
                                     .then(retVal => {


### PR DESCRIPTION
…e sqlite provider faster on large datasets

Keep backwards compatibility with the existing boolean flag