### PR TITLE
Using the same version of mocha for webtest files, fixing up broken after()

### DIFF
--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -64,20 +64,20 @@ function sleep(timeMs: number): SyncTasks.Promise<void> {
 }
 
 describe('NoSqlProvider', function () {
-    //this.timeout(60000);
-    after(callback => {
+    after('Cleaning up sqllite files', done => {
         if (cleanupFile) {
             var fs = require('fs');
-            fs.unlink('test', (err: any) => {
+            fs.unlink('./test', (err: any) => {
                 if (err) {
                     throw err;
                 }
-                console.log('path/file.txt was deleted');
-                callback();
+                console.log('test was deleted');
+                done();
             });
+        } else {
+            done();
         }
     });
-
     let provsToTest: string[];
     if (typeof window === 'undefined') {
         // Non-browser environment...

--- a/test.html
+++ b/test.html
@@ -2,12 +2,12 @@
 <head>
   <meta charset="utf-8">
   <title>Mocha Tests</title>
-  <link href="https://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.css" rel="stylesheet" />
+  <link href="node_modules/mocha/mocha.css" rel="stylesheet" />
 </head>
 <body>
   <div id="mocha"></div>
 
-  <script src="https://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.js"></script>
+  <script src="node_modules/mocha/mocha.js"></script>
 
   <script>mocha.setup({ui: 'bdd'})</script>
   <script src="dist/NoSqlProviderTestsPack.js"></script>


### PR DESCRIPTION
Using the same version of mocha for webtest files, fixing up broken after(). 
This is part of the effort to merge the masterKidan fork into the main microsoft repository. The masterKidan fork has fixes that remove the usage of SyncTasks() api that is no longer needed. We've found that as part of MSTeams this improves the performance of the application overall by switching to ES6 promises. The main reasoning here is due to the native support of es6 promises in v8 allow for faster execution time..