### PR TITLE
Updating everything to use es6 imports, setting sideEffects false

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "tslint": "tslint --project tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib --fix || true"
   },
   "main": "dist/NoSqlProvider.js",
+  "sideEffects": false,
   "dependencies": {
     "@types/lodash": "^4.14.149",
     "@types/sqlite3": "^3.1.6",

--- a/src/FullTextSearchHelpers.ts
+++ b/src/FullTextSearchHelpers.ts
@@ -6,13 +6,15 @@
  * Reusable helper classes and functions for supporting Full Text Search.
  */
 
-import _ = require('lodash');
+import {
+    words, map, mapKeys, deburr, filter, attempt, keyBy,
+    isError, pickBy, values, every, Dictionary, assign, take, trim as lodashTrim
+} from 'lodash';
 import { Ranges, trim } from 'regexp-i18n';
 import SyncTasks = require('synctasks');
 
-import NoSqlProvider = require('./NoSqlProvider');
-import { ItemType, KeyType } from './NoSqlProvider';
-import NoSqlProviderUtils = require('./NoSqlProviderUtils');
+import { DbIndex, IndexSchema, QuerySortOrder, FullTextTermResolution, ItemType, KeyType } from './NoSqlProvider';
+import { getValueForSingleKeypath, getSerializedKeyForKeypath } from './NoSqlProviderUtils';
 
 const _whitespaceRegexMatch = /\S+/g;
 
@@ -24,28 +26,28 @@ function sqlCompat(value: string): string {
 }
 
 export function breakAndNormalizeSearchPhrase(phrase: string): string[] {
-    // Deburr and tolower before using _.words since _.words breaks on CaseChanges.
-    const words = _.words(_.deburr(phrase).toLowerCase(), _whitespaceRegexMatch);
-    // _.map(_.mapKeys is faster than _.uniq since it's just a pile of strings.
-    const uniqueWordas = _.map(_.mapKeys(words), (value, key) => sqlCompat(key));
-    return _.filter(uniqueWordas, word => !!_.trim(word));
+    // Deburr and tolower before using words since words breaks on CaseChanges.
+    const deconstructedWords = words(deburr(phrase).toLowerCase(), _whitespaceRegexMatch);
+    // map(mapKeys is faster than uniq since it's just a pile of strings.
+    const uniqueWordas = map(mapKeys(deconstructedWords), (value, key) => sqlCompat(key));
+    return filter(uniqueWordas, word => !!lodashTrim(word));
 }
 
 export function getFullTextIndexWordsForItem(keyPath: string, item: any): string[] {
-    const rawString = NoSqlProviderUtils.getValueForSingleKeypath(item, keyPath);
+    const rawString = getValueForSingleKeypath(item, keyPath);
 
     return breakAndNormalizeSearchPhrase(rawString);
 }
 
-export abstract class DbIndexFTSFromRangeQueries implements NoSqlProvider.DbIndex {
+export abstract class DbIndexFTSFromRangeQueries implements DbIndex {
     protected _keyPath: string | string[];
 
-    constructor(protected _indexSchema: NoSqlProvider.IndexSchema|undefined, protected _primaryKeyPath: string | string[]) {
+    constructor(protected _indexSchema: IndexSchema|undefined, protected _primaryKeyPath: string | string[]) {
         this._keyPath = this._indexSchema ? this._indexSchema.keyPath : this._primaryKeyPath;
     }
 
     fullTextSearch(searchPhrase: string, 
-        resolution: NoSqlProvider.FullTextTermResolution = NoSqlProvider.FullTextTermResolution.And, limit?: number)
+        resolution: FullTextTermResolution = FullTextTermResolution.And, limit?: number)
             : SyncTasks.Promise<ItemType[]> {
         if (!this._indexSchema || !this._indexSchema.fullText) {
             return SyncTasks.Rejected('fullTextSearch performed against non-fullText index!');
@@ -56,33 +58,33 @@ export abstract class DbIndexFTSFromRangeQueries implements NoSqlProvider.DbInde
             return SyncTasks.Resolved([]);
         }
 
-        const promises = _.map(terms, term => {
+        const promises = map(terms, term => {
             const upperEnd = term.substr(0, term.length - 1) + String.fromCharCode(term.charCodeAt(term.length - 1) + 1);
             return this.getRange(term, upperEnd, false, true, false, limit);
         });
         return SyncTasks.all(promises).then(results => {
-            const uniquers = _.attempt(() => {
-                return _.map(results, resultSet => _.keyBy(resultSet, item =>
-                    NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._primaryKeyPath)));
+            const uniquers = attempt(() => {
+                return map(results, resultSet => keyBy(resultSet, item =>
+                    getSerializedKeyForKeypath(item, this._primaryKeyPath)));
             });
-            if (_.isError(uniquers)) {
+            if (isError(uniquers)) {
                 return SyncTasks.Rejected(uniquers);
             }
 
-            if (resolution === NoSqlProvider.FullTextTermResolution.Or) {
-                const data = _.values(_.assign({}, ...uniquers));
+            if (resolution === FullTextTermResolution.Or) {
+                const data = values(assign({}, ...uniquers));
                 if (limit) {
-                    return _.take(data, limit);
+                    return take(data, limit);
                 }
                 return data;
             }
 
-            if (resolution === NoSqlProvider.FullTextTermResolution.And) {
+            if (resolution === FullTextTermResolution.And) {
                 const [first, ...others] = uniquers;
-                const dic = _.pickBy(first, (value, key) => _.every(others, set => key in set)) as _.Dictionary<ItemType>;
-                const data = _.values(dic);
+                const dic = pickBy(first, (value, key) => every(others, set => key in set)) as Dictionary<ItemType>;
+                const data = values(dic);
                 if (limit) {
-                    return _.take(data, limit);
+                    return take(data, limit);
                 }
                 return data;
             }
@@ -91,12 +93,12 @@ export abstract class DbIndexFTSFromRangeQueries implements NoSqlProvider.DbInde
         });
     }
 
-    abstract getAll(reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number)
+    abstract getAll(reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number)
         : SyncTasks.Promise<ItemType[]>;
-    abstract getOnly(key: KeyType, reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number)
+    abstract getOnly(key: KeyType, reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number)
         : SyncTasks.Promise<ItemType[]>;
     abstract getRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
-        reverseOrSortOrder?: boolean|NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]>;
+        reverseOrSortOrder?: boolean|QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]>;
     abstract countAll(): SyncTasks.Promise<number>;
     abstract countOnly(key: KeyType): SyncTasks.Promise<number>;
     abstract countRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -6,14 +6,16 @@
  * NoSqlProvider provider setup for IndexedDB, a web browser storage module.
  */
 
-import _ = require('lodash');
+import { each, some, find, includes, isObject, attempt, isError, map, filter, compact, clone, isArray, noop } from 'lodash';
 import SyncTasks = require('synctasks');
 
-import FullTextSearchHelpers = require('./FullTextSearchHelpers');
-import NoSqlProvider = require('./NoSqlProvider');
-import { ItemType, KeyPathType, KeyType } from './NoSqlProvider';
-import NoSqlProviderUtils = require('./NoSqlProviderUtils');
-import TransactionLockHelper, { TransactionToken } from './TransactionLockHelper';
+import { DbIndexFTSFromRangeQueries, getFullTextIndexWordsForItem } from './FullTextSearchHelpers';
+import { DbProvider, DbSchema, DbStore, DbTransaction, StoreSchema, DbIndex, QuerySortOrder, IndexSchema, ItemType, KeyPathType, KeyType } from './NoSqlProvider';
+import {
+    isIE, isCompoundKeyPath, serializeKeyToString, getKeyForKeypath, arrayify, formListOfKeys,
+    getValueForSingleKeypath, getSerializedKeyForKeypath
+} from './NoSqlProviderUtils';
+import { TransactionLockHelper, TransactionToken } from './TransactionLockHelper';
 
 const IndexPrefix = 'nsp_i_';
 
@@ -53,7 +55,7 @@ function getBrowserInfo() {
 // The DbProvider implementation for IndexedDB.  This one is fairly straightforward since the library's access patterns pretty
 // closely mirror IndexedDB's.  We mostly do a lot of wrapping of the APIs into JQuery promises and have some fancy footwork to
 // do semi-automatic schema upgrades.
-export class IndexedDbProvider extends NoSqlProvider.DbProvider {
+export class IndexedDbProvider extends DbProvider {
     private _db: IDBDatabase|undefined;
     private _dbFactory: IDBFactory;
     private _fakeComplicatedKeys: boolean;
@@ -76,7 +78,7 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
             } else {
                 // IE/Edge's IndexedDB implementation doesn't support compound keys, so we have to fake it by implementing them similar to
                 // how the WebSqlProvider does, by concatenating the values into another field which then gets its own index.
-                this._fakeComplicatedKeys = NoSqlProviderUtils.isIE();
+                this._fakeComplicatedKeys = isIE();
             }
         }
     }
@@ -108,7 +110,7 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
         return task.promise();
     }
 
-    open(dbName: string, schema: NoSqlProvider.DbSchema, wipeIfExists: boolean, verbose: boolean): SyncTasks.Promise<void> {
+    open(dbName: string, schema: DbSchema, wipeIfExists: boolean, verbose: boolean): SyncTasks.Promise<void> {
         // Note: DbProvider returns null instead of a promise that needs waiting for.
         super.open(dbName, schema, wipeIfExists, verbose);
 
@@ -158,14 +160,14 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
             if (schema.lastUsableVersion && event.oldVersion < schema.lastUsableVersion) {
                 // Clear all stores if it's past the usable version
                 console.log('Old version detected (' + event.oldVersion + '), clearing all data');
-                _.each(db.objectStoreNames, name => {
+                each(db.objectStoreNames, name => {
                     db.deleteObjectStore(name);
                 });
             }
 
             // Delete dead stores
-            _.each(db.objectStoreNames, storeName => {
-                if (!_.some(schema.stores, store => store.name === storeName)) {
+            each(db.objectStoreNames, storeName => {
+                if (!some(schema.stores, store => store.name === storeName)) {
                     db.deleteObjectStore(storeName);
                 }
             });
@@ -173,10 +175,10 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
             // Create all stores
             for (const storeSchema of schema.stores) {
                 let store: IDBObjectStore;
-                const storeExistedBefore = _.includes(db.objectStoreNames, storeSchema.name);
+                const storeExistedBefore = includes(db.objectStoreNames, storeSchema.name);
                 if (!storeExistedBefore) { // store doesn't exist yet
                     let primaryKeyPath = storeSchema.primaryKeyPath;
-                    if (this._fakeComplicatedKeys && NoSqlProviderUtils.isCompoundKeyPath(primaryKeyPath)) {
+                    if (this._fakeComplicatedKeys && isCompoundKeyPath(primaryKeyPath)) {
                         // Going to have to hack the compound primary key index into a column, so here it is.
                         primaryKeyPath = 'nsp_pk';
                     }
@@ -187,12 +189,12 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
                     store = trans.objectStore(storeSchema.name);
 
                     // Check for any indexes no longer in the schema or have been changed
-                    _.each(store.indexNames, indexName => {
+                    each(store.indexNames, indexName => {
                         const index = store.index(indexName);
 
                         let nuke = false;
-                        const indexSchema = _.find(storeSchema.indexes, idx => idx.name === indexName);
-                        if (!indexSchema || !_.isObject(indexSchema)) {
+                        const indexSchema = find(storeSchema.indexes, idx => idx.name === indexName);
+                        if (!indexSchema || !isObject(indexSchema)) {
                             nuke = true;
                         } else if (typeof index.keyPath !== typeof indexSchema.keyPath) {
                             nuke = true;
@@ -224,11 +226,11 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
                 // Check any indexes in the schema that need to be created
                 if (storeSchema.indexes) {
                     for (const indexSchema of storeSchema.indexes) {
-                        if (!_.includes(store.indexNames, indexSchema.name)) {
+                        if (!includes(store.indexNames, indexSchema.name)) {
                             const keyPath = indexSchema.keyPath;
                             if (this._fakeComplicatedKeys) {
                                 if (indexSchema.multiEntry || indexSchema.fullText) {
-                                    if (NoSqlProviderUtils.isCompoundKeyPath(keyPath)) {
+                                    if (isCompoundKeyPath(keyPath)) {
                                         throw new Error('Can\'t use multiEntry and compound keys');
                                     } else {
                                         // Create an object store for the index
@@ -241,7 +243,7 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
                                             needsMigrate = true;
                                         }
                                     }
-                                } else if (NoSqlProviderUtils.isCompoundKeyPath(keyPath)) {
+                                } else if (isCompoundKeyPath(keyPath)) {
                                     // Going to have to hack the compound index into a column, so here it is.
                                     store.createIndex(indexSchema.name, IndexPrefix + indexSchema.name, {
                                         unique: indexSchema.unique
@@ -283,7 +285,7 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
                     const cursorReq = store.openCursor();
                     let thisIndexPutters: SyncTasks.Promise<void>[] = [];
                     migrationPutters.push(IndexedDbIndex.iterateOverCursorRequest(cursorReq, cursor => {
-                        const err = _.attempt(() => {
+                        const err = attempt(() => {
                             const item = removeFullTextMetadataAndReturn(storeSchema, (cursor as any).value);
 
                             thisIndexPutters.push(tStore.put(item));
@@ -291,7 +293,7 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
                         if (err) {
                             thisIndexPutters.push(SyncTasks.Rejected<void>(err));
                         }
-                    }).then(() => SyncTasks.all(thisIndexPutters).then(_.noop)));
+                    }).then(() => SyncTasks.all(thisIndexPutters).then(noop)));
                 }
             }
         };
@@ -325,11 +327,11 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
     }
 
     protected _deleteDatabaseInternal(): SyncTasks.Promise<void> {
-        const trans = _.attempt(() => {
+        const trans = attempt(() => {
             return this._dbFactory.deleteDatabase(this._dbName!!!);
         });
 
-        if (_.isError(trans)) {
+        if (isError(trans)) {
             return SyncTasks.Rejected(trans);
         }
         
@@ -345,7 +347,7 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
         return deferred.promise();
     }
 
-    openTransaction(storeNames: string[], writeNeeded: boolean): SyncTasks.Promise<NoSqlProvider.DbTransaction> {
+    openTransaction(storeNames: string[], writeNeeded: boolean): SyncTasks.Promise<DbTransaction> {
         if (!this._db) {
             return SyncTasks.Rejected('Can\'t openTransaction, database is closed');
         }
@@ -354,12 +356,12 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
 
         if (this._fakeComplicatedKeys) {
             // Clone the list becuase we're going to add fake store names to it
-            intStoreNames = _.clone(storeNames);
+            intStoreNames = clone(storeNames);
 
             // Pull the alternate multientry stores into the transaction as well
             let missingStores: string[] = [];
             for (const storeName of storeNames) {
-                let storeSchema = _.find(this._schema!!!.stores, s => s.name === storeName);
+                let storeSchema = find(this._schema!!!.stores, s => s.name === storeName);
                 if (!storeSchema) {
                     missingStores.push(storeName);
                     continue;
@@ -378,10 +380,10 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
         }
 
         return this._lockHelper!!!.openTransaction(storeNames, writeNeeded).then(transToken => {
-            const trans = _.attempt(() => {
+            const trans = attempt(() => {
                 return this._db!!!.transaction(intStoreNames, writeNeeded ? 'readwrite' : 'readonly');
             });
-            if (_.isError(trans)) {
+            if (isError(trans)) {
                 return SyncTasks.Rejected(trans);
             }
 
@@ -391,12 +393,12 @@ export class IndexedDbProvider extends NoSqlProvider.DbProvider {
 }
 
 // DbTransaction implementation for the IndexedDB DbProvider.
-class IndexedDbTransaction implements NoSqlProvider.DbTransaction {
+class IndexedDbTransaction implements DbTransaction {
     private _stores: IDBObjectStore[];
 
     constructor(private _trans: IDBTransaction, lockHelper: TransactionLockHelper|undefined, private _transToken: TransactionToken,
-            private _schema: NoSqlProvider.DbSchema, private _fakeComplicatedKeys: boolean) {
-        this._stores = _.map(this._transToken.storeNames, storeName => this._trans.objectStore(storeName));
+            private _schema: DbSchema, private _fakeComplicatedKeys: boolean) {
+        this._stores = map(this._transToken.storeNames, storeName => this._trans.objectStore(storeName));
 
         if (lockHelper) {
             // Chromium seems to have a bug in their indexeddb implementation that lets it start a timeout
@@ -442,9 +444,9 @@ class IndexedDbTransaction implements NoSqlProvider.DbTransaction {
         }
     }
 
-    getStore(storeName: string): NoSqlProvider.DbStore {
-        const store = _.find(this._stores, s => s.name === storeName);
-        const storeSchema = _.find(this._schema.stores, s => s.name === storeName);
+    getStore(storeName: string): DbStore {
+        const store = find(this._stores, s => s.name === storeName);
+        const storeSchema = find(this._schema.stores, s => s.name === storeName);
         if (!store || !storeSchema) {
             throw new Error('Store not found: ' + storeName);
         }
@@ -476,7 +478,7 @@ class IndexedDbTransaction implements NoSqlProvider.DbTransaction {
     }
 }
 
-function removeFullTextMetadataAndReturn<T>(schema: NoSqlProvider.StoreSchema, val: T): T {
+function removeFullTextMetadataAndReturn<T>(schema: StoreSchema, val: T): T {
     if (val && schema.indexes) {
         // We have full text index fields as real fields on the result, so nuke them before returning them to the caller.
         for (const index of schema.indexes) {
@@ -491,16 +493,16 @@ function removeFullTextMetadataAndReturn<T>(schema: NoSqlProvider.StoreSchema, v
 
 // DbStore implementation for the IndexedDB DbProvider.  Again, fairly closely maps to the standard IndexedDB spec, aside from
 // a bunch of hacks to support compound keypaths on IE.
-class IndexedDbStore implements NoSqlProvider.DbStore {
-    constructor(private _store: IDBObjectStore, private _indexStores: IDBObjectStore[], private _schema: NoSqlProvider.StoreSchema,
+class IndexedDbStore implements DbStore {
+    constructor(private _store: IDBObjectStore, private _indexStores: IDBObjectStore[], private _schema: StoreSchema,
             private _fakeComplicatedKeys: boolean) {
         // NOP
     }
 
     get(key: KeyType): SyncTasks.Promise<ItemType|undefined> {
-        if (this._fakeComplicatedKeys && NoSqlProviderUtils.isCompoundKeyPath(this._schema.primaryKeyPath)) {
-            const err = _.attempt(() => {
-                key = NoSqlProviderUtils.serializeKeyToString(key, this._schema.primaryKeyPath);
+        if (this._fakeComplicatedKeys && isCompoundKeyPath(this._schema.primaryKeyPath)) {
+            const err = attempt(() => {
+                key = serializeKeyToString(key, this._schema.primaryKeyPath);
             });
             if (err) {
                 return SyncTasks.Rejected(err);
@@ -512,71 +514,71 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
     }
 
     getMultiple(keyOrKeys: KeyType|KeyType[]): SyncTasks.Promise<ItemType[]> {
-        const keys = _.attempt(() => {
-            const keys = NoSqlProviderUtils.formListOfKeys(keyOrKeys, this._schema.primaryKeyPath);
+        const keys = attempt(() => {
+            const keys = formListOfKeys(keyOrKeys, this._schema.primaryKeyPath);
 
-            if (this._fakeComplicatedKeys && NoSqlProviderUtils.isCompoundKeyPath(this._schema.primaryKeyPath)) {
-                return _.map(keys, key => NoSqlProviderUtils.serializeKeyToString(key, this._schema.primaryKeyPath));
+            if (this._fakeComplicatedKeys && isCompoundKeyPath(this._schema.primaryKeyPath)) {
+                return map(keys, key => serializeKeyToString(key, this._schema.primaryKeyPath));
             }
             return keys;
         });
-        if (_.isError(keys)) {
+        if (isError(keys)) {
             return SyncTasks.Rejected(keys);
         }
 
         // There isn't a more optimized way to do this with indexeddb, have to get the results one by one
         return SyncTasks.all(
-                _.map(keys, key => IndexedDbProvider.WrapRequest<ItemType|undefined>(this._store.get(key))
+                map(keys, key => IndexedDbProvider.WrapRequest<ItemType|undefined>(this._store.get(key))
                 .then(val => removeFullTextMetadataAndReturn(this._schema, val))))
-            .then(_.compact);
+            .then(compact);
     }
 
     put(itemOrItems: ItemType|ItemType[]): SyncTasks.Promise<void> {
-        let items = NoSqlProviderUtils.arrayify(itemOrItems);
+        let items = arrayify(itemOrItems);
 
         let promises: SyncTasks.Promise<void>[] = [];
 
-        const err = _.attempt(() => {
+        const err = attempt(() => {
             for (const item of items) {
                 let errToReport: any;
                 let fakedPk = false;
 
                 if (this._fakeComplicatedKeys) {
                     // Fill out any compound-key indexes
-                    if (NoSqlProviderUtils.isCompoundKeyPath(this._schema.primaryKeyPath)) {
+                    if (isCompoundKeyPath(this._schema.primaryKeyPath)) {
                         fakedPk = true;
-                        (item as any)['nsp_pk'] = NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._schema.primaryKeyPath);
+                        (item as any)['nsp_pk'] = getSerializedKeyForKeypath(item, this._schema.primaryKeyPath);
                     }
 
                     if (this._schema.indexes) {
                         for (const index of this._schema.indexes) {
                             if (index.multiEntry || index.fullText) {
-                                let indexStore = _.find(this._indexStores, store => store.name === this._schema.name + '_' + index.name)!!!;
+                                let indexStore = find(this._indexStores, store => store.name === this._schema.name + '_' + index.name)!!!;
 
                                 let keys: any[];
                                 if (index.fullText) {
-                                    keys = FullTextSearchHelpers.getFullTextIndexWordsForItem(<string>index.keyPath, item);
+                                    keys = getFullTextIndexWordsForItem(<string>index.keyPath, item);
                                 } else {
                                     // Get each value of the multientry and put it into the index store
-                                    const valsRaw = NoSqlProviderUtils.getValueForSingleKeypath(item, <string>index.keyPath);
+                                    const valsRaw = getValueForSingleKeypath(item, <string>index.keyPath);
                                     // It might be an array of multiple entries, so just always go with array-based logic
-                                    keys = NoSqlProviderUtils.arrayify(valsRaw);
+                                    keys = arrayify(valsRaw);
                                 }
 
                                 let refKey: any;
-                                const err = _.attempt(() => {
+                                const err = attempt(() => {
                                     // We're using normal indexeddb tables to store the multientry indexes, so we only need to use the key
                                     // serialization if the multientry keys ALSO are compound.
-                                    if (NoSqlProviderUtils.isCompoundKeyPath(index.keyPath)) {
-                                        keys = _.map(keys, val => NoSqlProviderUtils.serializeKeyToString(val, <string>index.keyPath));
+                                    if (isCompoundKeyPath(index.keyPath)) {
+                                        keys = map(keys, val => serializeKeyToString(val, <string>index.keyPath));
                                     }
 
                                     // We need to reference the PK of the actual row we're using here, so calculate the actual PK -- if 
                                     // it's compound, we're already faking complicated keys, so we know to serialize it to a string.  If
                                     // not, use the raw value.
-                                    refKey = NoSqlProviderUtils.getKeyForKeypath(item, this._schema.primaryKeyPath);
-                                    if (_.isArray(this._schema.primaryKeyPath)) {
-                                        refKey = NoSqlProviderUtils.serializeKeyToString(refKey, this._schema.primaryKeyPath);
+                                    refKey = getKeyForKeypath(item, this._schema.primaryKeyPath);
+                                    if (isArray(this._schema.primaryKeyPath)) {
+                                        refKey = serializeKeyToString(refKey, this._schema.primaryKeyPath);
                                     }
                                 });
 
@@ -592,7 +594,7 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
                                 })
                                     .then(() => {
                                         // After nuking the existing entries, add the new ones
-                                        let iputters = _.map(keys, key => {
+                                        let iputters = map(keys, key => {
                                             const indexObj = {
                                                 key: key,
                                                 refkey: refKey
@@ -600,10 +602,10 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
                                             return IndexedDbProvider.WrapRequest<void>(indexStore.put(indexObj));
                                         });
                                         return SyncTasks.all(iputters);
-                                    }).then(_.noop));
-                            } else if (NoSqlProviderUtils.isCompoundKeyPath(index.keyPath)) {
+                                    }).then(noop));
+                            } else if (isCompoundKeyPath(index.keyPath)) {
                                 (item as any)[IndexPrefix + index.name] =
-                                    NoSqlProviderUtils.getSerializedKeyForKeypath(item, index.keyPath);
+                                    getSerializedKeyForKeypath(item, index.keyPath);
                             }
                         }
                     }
@@ -611,13 +613,13 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
                     for (const index of this._schema.indexes) {
                         if (index.fullText) {
                             (item as any)[IndexPrefix + index.name] =
-                                FullTextSearchHelpers.getFullTextIndexWordsForItem(<string>index.keyPath, item);
+                                getFullTextIndexWordsForItem(<string>index.keyPath, item);
                         }
                     }
                 }
 
                 if (!errToReport) {
-                    errToReport = _.attempt(() => {
+                    errToReport = attempt(() => {
                         const req = this._store.put(item);
 
                         if (fakedPk) {
@@ -640,40 +642,40 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
             return SyncTasks.Rejected<void>(err);
         }
 
-        return SyncTasks.all(promises).then(_.noop);
+        return SyncTasks.all(promises).then(noop);
     }
 
     remove(keyOrKeys: KeyType|KeyType[]): SyncTasks.Promise<void> {
-        const keys = _.attempt(() => {
-            const keys = NoSqlProviderUtils.formListOfKeys(keyOrKeys, this._schema.primaryKeyPath);
+        const keys = attempt(() => {
+            const keys = formListOfKeys(keyOrKeys, this._schema.primaryKeyPath);
 
-            if (this._fakeComplicatedKeys && NoSqlProviderUtils.isCompoundKeyPath(this._schema.primaryKeyPath)) {
-                return _.map(keys, key => NoSqlProviderUtils.serializeKeyToString(key, this._schema.primaryKeyPath));
+            if (this._fakeComplicatedKeys && isCompoundKeyPath(this._schema.primaryKeyPath)) {
+                return map(keys, key => serializeKeyToString(key, this._schema.primaryKeyPath));
             }
             return keys;
         });
-        if (_.isError(keys)) {
+        if (isError(keys)) {
             return SyncTasks.Rejected<void>(keys);
         }
 
-        return SyncTasks.all(_.map(keys, key => {
-            if (this._fakeComplicatedKeys && _.some(this._schema.indexes, index => index.multiEntry || index.fullText)) {
+        return SyncTasks.all(map(keys, key => {
+            if (this._fakeComplicatedKeys && some(this._schema.indexes, index => index.multiEntry || index.fullText)) {
                 // If we're faking keys and there's any multientry indexes, we have to do the way more complicated version...
                 return IndexedDbProvider.WrapRequest<any>(this._store.get(key)).then(item => {
                     if (item) {
                         // Go through each multiEntry index and nuke the referenced items from the sub-stores
-                        let promises = _.map(_.filter(this._schema.indexes, index => !!index.multiEntry), index => {
-                            let indexStore = _.find(this._indexStores, store => store.name === this._schema.name + '_' + index.name)!!!;
-                            const refKey = _.attempt(() => {
+                        let promises = map(filter(this._schema.indexes, index => !!index.multiEntry), index => {
+                            let indexStore = find(this._indexStores, store => store.name === this._schema.name + '_' + index.name)!!!;
+                            const refKey = attempt(() => {
                                 // We need to reference the PK of the actual row we're using here, so calculate the actual PK -- if it's
                                 // compound, we're already faking complicated keys, so we know to serialize it to a string.  If not, use the
                                 // raw value.
-                                const tempRefKey = NoSqlProviderUtils.getKeyForKeypath(item, this._schema.primaryKeyPath)!!!;
-                                return _.isArray(this._schema.primaryKeyPath) ? 
-                                    NoSqlProviderUtils.serializeKeyToString(tempRefKey, this._schema.primaryKeyPath) :
+                                const tempRefKey = getKeyForKeypath(item, this._schema.primaryKeyPath)!!!;
+                                return isArray(this._schema.primaryKeyPath) ? 
+                                    serializeKeyToString(tempRefKey, this._schema.primaryKeyPath) :
                                     tempRefKey;
                             });
-                            if (_.isError(refKey)) {
+                            if (isError(refKey)) {
                                 return SyncTasks.Rejected<void>(refKey);
                             }
 
@@ -685,24 +687,24 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
                         });
                         // Also remember to nuke the item from the actual store
                         promises.push(IndexedDbProvider.WrapRequest<void>(this._store['delete'](key)));
-                        return SyncTasks.all(promises).then(_.noop);
+                        return SyncTasks.all(promises).then(noop);
                     }
                     return undefined;
                 });
             }
 
             return IndexedDbProvider.WrapRequest<void>(this._store['delete'](key));
-        })).then(_.noop);
+        })).then(noop);
     }
 
-    openIndex(indexName: string): NoSqlProvider.DbIndex {
-        const indexSchema = _.find(this._schema.indexes, idx => idx.name === indexName);
+    openIndex(indexName: string): DbIndex {
+        const indexSchema = find(this._schema.indexes, idx => idx.name === indexName);
         if (!indexSchema) {
             throw new Error('Index not found: ' + indexName);
         }
 
         if (this._fakeComplicatedKeys && (indexSchema.multiEntry || indexSchema.fullText)) {
-            const store = _.find(this._indexStores, indexStore => indexStore.name === this._schema.name + '_' + indexSchema.name);
+            const store = find(this._indexStores, indexStore => indexStore.name === this._schema.name + '_' + indexSchema.name);
             if (!store) {
                 throw new Error('Indexstore not found: ' + this._schema.name + '_' + indexSchema.name);
             }
@@ -717,7 +719,7 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
         }
     }
 
-    openPrimaryKey(): NoSqlProvider.DbIndex {
+    openPrimaryKey(): DbIndex {
         return new IndexedDbIndex(this._store, undefined, this._schema.primaryKeyPath, this._fakeComplicatedKeys);
     }
 
@@ -727,17 +729,17 @@ class IndexedDbStore implements NoSqlProvider.DbStore {
             storesToClear = storesToClear.concat(this._indexStores);
         }
 
-        let promises = _.map(storesToClear, store => IndexedDbProvider.WrapRequest(store.clear()));
+        let promises = map(storesToClear, store => IndexedDbProvider.WrapRequest(store.clear()));
 
-        return SyncTasks.all(promises).then(_.noop);
+        return SyncTasks.all(promises).then(noop);
     }
 }
 
 // DbIndex implementation for the IndexedDB DbProvider.  Fairly closely maps to the standard IndexedDB spec, aside from
 // a bunch of hacks to support compound keypaths on IE and some helpers to make the caller not have to walk the awkward cursor
 // result APIs to get their result list.  Also added ability to use an "index" for opening the primary key on a store.
-class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
-    constructor(private _store: IDBIndex | IDBObjectStore, indexSchema: NoSqlProvider.IndexSchema|undefined,
+class IndexedDbIndex extends DbIndexFTSFromRangeQueries {
+    constructor(private _store: IDBIndex | IDBObjectStore, indexSchema: IndexSchema|undefined,
             primaryKeyPath: KeyPathType, private _fakeComplicatedKeys: boolean, private _fakedOriginalStore?: IDBObjectStore) {
         super(indexSchema, primaryKeyPath);
     }
@@ -747,7 +749,7 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
             // Get based on the keys from the index store, which have refkeys that point back to the original store
             return IndexedDbIndex.getFromCursorRequest<{ key: string, refkey: any }>(req, limit, offset).then(rets => {
                 // Now get the original items using the refkeys from the index store, which are PKs on the main store
-                const getters = _.map(rets, ret => IndexedDbProvider.WrapRequest<{ key: string, refkey: any }>(
+                const getters = map(rets, ret => IndexedDbProvider.WrapRequest<{ key: string, refkey: any }>(
                     this._fakedOriginalStore!!!.get(ret.refkey)));
                 return SyncTasks.all(getters);
             });
@@ -756,8 +758,8 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
         }
     }
 
-    getAll(reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
-        const reverse = reverseOrSortOrder === true || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
+    getAll(reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
+        const reverse = reverseOrSortOrder === true || reverseOrSortOrder === QuerySortOrder.Reverse;
         // ************************* Don't change this null to undefined, IE chokes on it... *****************************
         // ************************* Don't change this null to undefined, IE chokes on it... *****************************
         // ************************* Don't change this null to undefined, IE chokes on it... *****************************
@@ -765,37 +767,37 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
         return this._resolveCursorResult(req, limit, offset);
     }
 
-    getOnly(key: KeyType, reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number)
+    getOnly(key: KeyType, reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number)
             : SyncTasks.Promise<ItemType[]> {
-        const keyRange = _.attempt(() => {
+        const keyRange = attempt(() => {
             return this._getKeyRangeForOnly(key);
         });
-        if (_.isError(keyRange)) {
+        if (isError(keyRange)) {
             return SyncTasks.Rejected(keyRange);
         }
-        const reverse = reverseOrSortOrder === true || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
+        const reverse = reverseOrSortOrder === true || reverseOrSortOrder === QuerySortOrder.Reverse;
         const req = this._store.openCursor(keyRange, reverse ? 'prev' : 'next');
         return this._resolveCursorResult(req, limit, offset);
     }
 
     // Warning: This function can throw, make sure to trap.
     private _getKeyRangeForOnly(key: KeyType): IDBKeyRange {
-        if (this._fakeComplicatedKeys && NoSqlProviderUtils.isCompoundKeyPath(this._keyPath)) {
-            return IDBKeyRange.only(NoSqlProviderUtils.serializeKeyToString(key, this._keyPath));
+        if (this._fakeComplicatedKeys && isCompoundKeyPath(this._keyPath)) {
+            return IDBKeyRange.only(serializeKeyToString(key, this._keyPath));
         }
         return IDBKeyRange.only(key);
     }
 
     getRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
-            reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
-        const keyRange = _.attempt(() => {
+            reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
+        const keyRange = attempt(() => {
             return this._getKeyRangeForRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
         });
-        if (_.isError(keyRange)) {
+        if (isError(keyRange)) {
             return SyncTasks.Rejected(keyRange);
         }
 
-        const reverse = reverseOrSortOrder === true || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
+        const reverse = reverseOrSortOrder === true || reverseOrSortOrder === QuerySortOrder.Reverse;
         const req = this._store.openCursor(keyRange, reverse ? 'prev' : 'next');
         return this._resolveCursorResult(req, limit, offset);
     }
@@ -804,10 +806,10 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
     private _getKeyRangeForRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean,
                 highRangeExclusive?: boolean)
             : IDBKeyRange {
-        if (this._fakeComplicatedKeys && NoSqlProviderUtils.isCompoundKeyPath(this._keyPath)) {
+        if (this._fakeComplicatedKeys && isCompoundKeyPath(this._keyPath)) {
             // IE has to switch to hacky pre-joined-compound-keys
-            return IDBKeyRange.bound(NoSqlProviderUtils.serializeKeyToString(keyLowRange, this._keyPath),
-                NoSqlProviderUtils.serializeKeyToString(keyHighRange, this._keyPath),
+            return IDBKeyRange.bound(serializeKeyToString(keyLowRange, this._keyPath),
+                serializeKeyToString(keyHighRange, this._keyPath),
                 lowRangeExclusive, highRangeExclusive);
         }
         return IDBKeyRange.bound(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
@@ -819,10 +821,10 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
     }
 
     countOnly(key: KeyType): SyncTasks.Promise<number> {
-        const keyRange = _.attempt(() => {
+        const keyRange = attempt(() => {
             return this._getKeyRangeForOnly(key);
         });
-        if (_.isError(keyRange)) {
+        if (isError(keyRange)) {
             return SyncTasks.Rejected(keyRange);
         }
 
@@ -832,10 +834,10 @@ class IndexedDbIndex extends FullTextSearchHelpers.DbIndexFTSFromRangeQueries {
 
     countRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean)
             : SyncTasks.Promise<number> {
-        let keyRange = _.attempt(() => {
+        let keyRange = attempt(() => {
             return this._getKeyRangeForRange(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
         });
-        if (_.isError(keyRange)) {
+        if (isError(keyRange)) {
             return SyncTasks.Rejected(keyRange);
         }
 

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -10,8 +10,8 @@
  * be required piecemeal.
  */
 
-import _ = require('lodash');
-import SyncTasks = require('synctasks');
+import { noop, attempt, isError } from 'lodash';
+import * as SyncTasks from 'synctasks';
 
 // Basic nomenclature types for everyone to agree on.
 export type ItemType = object;
@@ -131,15 +131,15 @@ export abstract class DbProvider {
 
         return this.openTransaction(storeNames, true).then(trans => {
             const clearers = storeNames.map(storeName => {
-                const store = _.attempt(() => {
+                const store = attempt(() => {
                     return trans.getStore(storeName);
                 });
-                if (!store || _.isError(store)) {
+                if (!store || isError(store)) {
                     return SyncTasks.Rejected<void>('Store "' + storeName + '" not found');
                 }
                 return store.clearAllData();
             });
-            return SyncTasks.all(clearers).then(_.noop);
+            return SyncTasks.all(clearers).then(noop);
         });
     }
 
@@ -147,10 +147,10 @@ export abstract class DbProvider {
 
     private _getStoreTransaction(storeName: string, readWrite: boolean): SyncTasks.Promise<DbStore> {
         return this.openTransaction([storeName], readWrite).then(trans => {
-            const store = _.attempt(() => {
+            const store = attempt(() => {
                 return trans.getStore(storeName);
             });
-            if (!store || _.isError(store)) {
+            if (!store || isError(store)) {
                 return SyncTasks.Rejected('Store "' + storeName + '" not found');
             }
             return store;
@@ -184,10 +184,10 @@ export abstract class DbProvider {
 
     private _getStoreIndexTransaction(storeName: string, readWrite: boolean, indexName: string|undefined): SyncTasks.Promise<DbIndex> {
         return this._getStoreTransaction(storeName, readWrite).then(store => {
-            const index = _.attempt(() => {
+            const index = attempt(() => {
                 return indexName ? store.openIndex(indexName) : store.openPrimaryKey();
             });
-            if (!index || _.isError(index)) {
+            if (!index || isError(index)) {
                 return SyncTasks.Rejected('Index "' + indexName + '" not found');
             }
             return index;

--- a/src/NoSqlProviderUtils.ts
+++ b/src/NoSqlProviderUtils.ts
@@ -6,7 +6,7 @@
  * Reusable helper functions for NoSqlProvider providers/transactions/etc.
  */
 
-import _ = require('lodash');
+import { map, isArray, some, isNull, isDate, get, isUndefined, isObject } from 'lodash';
 
 import { KeyComponentType, KeyPathType, KeyType } from './NoSqlProvider';
 
@@ -29,7 +29,7 @@ export function isSafari() {
 }
 
 export function arrayify<T>(obj: T | T[]): T[] {
-    return _.isArray(obj) ? <T[]>obj : [<T>obj];
+    return isArray(obj) ? <T[]>obj : [<T>obj];
 }
 
 // Constant string for joining compound keypaths for websql and IE indexeddb.  There may be marginal utility in using a more obscure
@@ -50,13 +50,13 @@ export function getSerializedKeyForKeypath(obj: any, keyPathRaw: KeyPathType): s
 export function getKeyForKeypath(obj: any, keyPathRaw: KeyPathType): KeyType|undefined {
     const keyPathArray = arrayify(keyPathRaw);
 
-    const values = _.map(keyPathArray, kp => getValueForSingleKeypath(obj, kp));
-    if (_.some(values, val => _.isNull(val) || _.isUndefined(val))) {
+    const values = map(keyPathArray, kp => getValueForSingleKeypath(obj, kp));
+    if (some(values, val => isNull(val) || isUndefined(val))) {
         // If any components of the key are null/undefined, then the result is undefined
         return undefined;
     }
 
-    if (!_.isArray(keyPathRaw)) {
+    if (!isArray(keyPathRaw)) {
         return values[0];
     } else {
         return values;
@@ -65,20 +65,20 @@ export function getKeyForKeypath(obj: any, keyPathRaw: KeyPathType): KeyType|und
 
 // Internal helper function for getting a value out of a standard keypath.
 export function getValueForSingleKeypath(obj: any, singleKeyPath: string): any {
-    return _.get(obj, singleKeyPath, undefined);
+    return get(obj, singleKeyPath, undefined);
 }
 
 export function isCompoundKeyPath(keyPath: KeyPathType) {
-    return _.isArray(keyPath) && keyPath.length > 1;
+    return isArray(keyPath) && keyPath.length > 1;
 }
 
 export function formListOfKeys(keyOrKeys: KeyType|KeyType[], keyPath: KeyPathType): any[] {
     if (isCompoundKeyPath(keyPath)) {
-        if (!_.isArray(keyOrKeys)) {
+        if (!isArray(keyOrKeys)) {
             throw new Error('formListOfKeys called with a compound keypath (' + JSON.stringify(keyPath) +
                 ') but a non-compound keyOrKeys (' + JSON.stringify(keyOrKeys) + ')');
         }
-        if (!_.isArray(keyOrKeys[0])) {
+        if (!isArray(keyOrKeys[0])) {
             // Looks like a single compound key, so make it a list of a single key
             return [keyOrKeys];
         }
@@ -95,14 +95,14 @@ export function serializeValueToOrderableString(val: KeyComponentType): string {
     if (typeof val === 'number') {
         return 'A' + serializeNumberToOrderableString(val as number);
     }
-    if (_.isDate(val)) {
+    if (isDate(val)) {
         return 'B' + serializeNumberToOrderableString((val as Date).getTime());
     }
     if (typeof val === 'string') {
         return 'C' + (val as string);
     }
 
-    const type = _.isObject(val) ? Object.getPrototypeOf(val).constructor : typeof val;
+    const type = isObject(val) ? Object.getPrototypeOf(val).constructor : typeof val;
     throw new Error('Type \'' + type + '\' unsupported at this time.  Only numbers, Dates, and strings are currently supported.');
 }
 
@@ -144,14 +144,14 @@ export function serializeNumberToOrderableString(n: number) {
 
 export function serializeKeyToString(key: KeyType, keyPath: KeyPathType): string {
     if (isCompoundKeyPath(keyPath)) {
-        if (_.isArray(key)) {
-            return _.map(key, k => serializeValueToOrderableString(k)).join(keypathJoinerString);
+        if (isArray(key)) {
+            return map(key, k => serializeValueToOrderableString(k)).join(keypathJoinerString);
         } else {
             throw new Error('serializeKeyToString called with a compound keypath (' + JSON.stringify(keyPath) +
                 ') but a non-compound key (' + JSON.stringify(key) + ')');
         }
     } else {
-        if (_.isArray(key)) {
+        if (isArray(key)) {
             throw new Error('serializeKeyToString called with a non-compound keypath (' + JSON.stringify(keyPath) +
                 ') but a compound key (' + JSON.stringify(key) + ')');
         } else {
@@ -161,5 +161,5 @@ export function serializeKeyToString(key: KeyType, keyPath: KeyPathType): string
 }
 
 export function formListOfSerializedKeys(keyOrKeys: KeyType|KeyType[], keyPath: KeyPathType): string[] {
-    return _.map(formListOfKeys(keyOrKeys, keyPath), key => serializeKeyToString(key, keyPath));
+    return map(formListOfKeys(keyOrKeys, keyPath), key => serializeKeyToString(key, keyPath));
 }

--- a/src/SqlProviderBase.ts
+++ b/src/SqlProviderBase.ts
@@ -6,14 +6,13 @@
  * Abstract helpers for all NoSqlProvider DbProviders that are based on SQL backings.
  */
 
-import assert = require('assert');
-import _ = require('lodash');
-import SyncTasks = require('synctasks');
+import { ok } from 'assert';
+import { repeat, map, isError, attempt, includes, filter, flatten, partition, intersection, some, keyBy, noop, isEqual, find, indexOf, fill, each } from 'lodash';
+import * as SyncTasks from 'synctasks';
 
-import FullTextSearchHelpers = require('./FullTextSearchHelpers');
-import NoSqlProvider = require('./NoSqlProvider');
-import { ItemType } from './NoSqlProvider';
-import NoSqlProviderUtils = require('./NoSqlProviderUtils');
+import { getFullTextIndexWordsForItem, breakAndNormalizeSearchPhrase } from './FullTextSearchHelpers';
+import { ItemType, IndexSchema, StoreSchema, DbProvider, DbIndex, DbSchema, DbStore, DbTransaction, QuerySortOrder, FullTextTermResolution } from './NoSqlProvider';
+import { serializeKeyToString, isCompoundKeyPath, formListOfSerializedKeys, getSerializedKeyForKeypath, arrayify, getValueForSingleKeypath } from './NoSqlProviderUtils';
 
 // Extending interfaces that should be in lib.d.ts but aren't for some reason.
 export interface SQLVoidCallback {
@@ -50,24 +49,24 @@ const DB_MIGRATION_MAX_BYTE_TARGET = 1000000;
 interface IndexMetadata {
     key: string;
     storeName: string;
-    index: NoSqlProvider.IndexSchema;
+    index: IndexSchema;
 }
 
-function getIndexIdentifier(storeSchema: NoSqlProvider.StoreSchema, index: NoSqlProvider.IndexSchema): string {
+function getIndexIdentifier(storeSchema: StoreSchema, index: IndexSchema): string {
     return storeSchema.name + '_' + index.name;
 }
 
 // Certain indexes use a separate table for pivot:
 // * Multientry indexes
 // * Full-text indexes that support FTS3
-function indexUsesSeparateTable(indexSchema: NoSqlProvider.IndexSchema, supportsFTS3: boolean): boolean {
+function indexUsesSeparateTable(indexSchema: IndexSchema, supportsFTS3: boolean): boolean {
     return indexSchema.multiEntry || (!!indexSchema.fullText && supportsFTS3);
 }
 
 function generateParamPlaceholder(count: number): string {
-    assert.ok(count >= 1, 'Must provide at least one parameter to SQL statement');
+    ok(count >= 1, 'Must provide at least one parameter to SQL statement');
     // Generate correct count of ?'s and slice off trailing comma
-    return _.repeat('?,', count).slice(0, -1);
+    return repeat('?,', count).slice(0, -1);
 }
 
 const FakeFTSJoinToken = '^$^';
@@ -75,7 +74,7 @@ const FakeFTSJoinToken = '^$^';
 // Limit LIMIT numbers to a reasonable size to not break queries.
 const LimitMax = Math.pow(2, 32);
 
-export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
+export abstract class SqlProviderBase extends DbProvider {
     constructor(protected _supportsFTS3: boolean) {
         super();
         // NOP
@@ -146,11 +145,11 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
         return this._getMetadata(trans).then(fullMeta => {
             // Get Index metadatas
             let indexMetadata: IndexMetadata[] =
-                _.map(fullMeta, meta => {
-                    const metaObj = _.attempt(() => {
+                map(fullMeta, meta => {
+                    const metaObj = attempt(() => {
                         return JSON.parse(meta.value);
                     });
-                    if (_.isError(metaObj)) {
+                    if (isError(metaObj)) {
                         return undefined;
                     }
                     return metaObj;
@@ -219,7 +218,7 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                         const placeholder = generateParamPlaceholder(metasToDelete.length);
 
                         return trans.runQuery('DELETE FROM metadata WHERE name IN (' + placeholder + ')',
-                            _.map(metasToDelete, meta => meta.key));
+                            map(metasToDelete, meta => meta.key));
                     };
 
                     // Check each table!
@@ -230,7 +229,7 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                             console.log('Old version detected (' + oldVersion + '), clearing all tables');
                         }
 
-                        dropQueries = _.map(tableNames, name => trans.runQuery('DROP TABLE ' + name));
+                        dropQueries = map(tableNames, name => trans.runQuery('DROP TABLE ' + name));
 
                         if (indexMetadata.length > 0) {
                             // Drop all existing metadata
@@ -251,21 +250,21 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                                 }
                             }
                         }
-                        let tableNamesNotNeeded = _.filter(tableNames, name => !_.includes(tableNamesNeeded, name));
-                        dropQueries = _.flatten(_.map(tableNamesNotNeeded, name => {
+                        let tableNamesNotNeeded = filter(tableNames, name => !includes(tableNamesNeeded, name));
+                        dropQueries = flatten(map(tableNamesNotNeeded, name => {
                             const transList: SyncTasks.Promise<any>[] = [trans.runQuery('DROP TABLE ' + name)];
-                            const metasToDelete = _.filter(indexMetadata, meta => meta.storeName === name);
-                            const metaKeysToDelete = _.map(metasToDelete, meta => meta.key);
+                            const metasToDelete = filter(indexMetadata, meta => meta.storeName === name);
+                            const metaKeysToDelete = map(metasToDelete, meta => meta.key);
 
                             // Clean up metas
                             if (metasToDelete.length > 0) {
                                 transList.push(deleteFromMeta(metasToDelete));
-                                indexMetadata = _.filter(indexMetadata, meta => !_.includes(metaKeysToDelete, meta.key));
+                                indexMetadata = filter(indexMetadata, meta => !includes(metaKeysToDelete, meta.key));
                             }
                             return transList;
                         }));
 
-                        tableNames = _.filter(tableNames, name => _.includes(tableNamesNeeded, name));
+                        tableNames = filter(tableNames, name => includes(tableNamesNeeded, name));
                     }
 
                     const tableColumns: { [table: string]: string[] } = {};
@@ -292,9 +291,9 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                         for (const storeSchema of this._schema!!!.stores) {
 
                             // creates indexes for provided schemas 
-                            const indexMaker = (indexes: NoSqlProvider.IndexSchema[] = []) => {
+                            const indexMaker = (indexes: IndexSchema[] = []) => {
                                 let metaQueries: SyncTasks.Promise<any>[] = [];
-                                const indexQueries = _.map(indexes, index => {
+                                const indexQueries = map(indexes, index => {
                                     const indexIdentifier = getIndexIdentifier(storeSchema, index);
 
                                     // Store meta for the index
@@ -306,7 +305,7 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                                     metaQueries.push(this._storeIndexMetadata(trans, newMeta));
                                     // Go over each index and see if we need to create an index or a table for a multiEntry index
                                     if (index.multiEntry) {
-                                        if (NoSqlProviderUtils.isCompoundKeyPath(index.keyPath)) {
+                                        if (isCompoundKeyPath(index.keyPath)) {
                                             return SyncTasks.Rejected('Can\'t use multiEntry and compound keys');
                                         } else {
                                             return trans.runQuery('CREATE TABLE IF NOT EXISTS ' + indexIdentifier +
@@ -340,41 +339,41 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                             fieldList.push('nsp_pk TEXT PRIMARY KEY');
                             fieldList.push('nsp_data TEXT');
 
-                            const columnBasedIndices = _.filter(storeSchema.indexes, index =>
+                            const columnBasedIndices = filter(storeSchema.indexes, index =>
                                 !indexUsesSeparateTable(index, this._supportsFTS3));
 
-                            const indexColumnsNames = _.map(columnBasedIndices, index => 'nsp_i_' + index.name + ' TEXT');
+                            const indexColumnsNames = map(columnBasedIndices, index => 'nsp_i_' + index.name + ' TEXT');
                             fieldList = fieldList.concat(indexColumnsNames);
                             const tableMakerSql = 'CREATE TABLE ' + storeSchema.name + ' (' + fieldList.join(', ') + ')';
                             
-                            const currentIndexMetas = _.filter(indexMetadata, meta => meta.storeName === storeSchema.name);
+                            const currentIndexMetas = filter(indexMetadata, meta => meta.storeName === storeSchema.name);
                             
-                            const indexIdentifierDictionary = _.keyBy(storeSchema.indexes, index => getIndexIdentifier(storeSchema, index));
-                            const indexMetaDictionary = _.keyBy(currentIndexMetas, meta => meta.key);
+                            const indexIdentifierDictionary = keyBy(storeSchema.indexes, index => getIndexIdentifier(storeSchema, index));
+                            const indexMetaDictionary = keyBy(currentIndexMetas, meta => meta.key);
 
                             // find which indices in the schema existed / did not exist before
-                            const [newIndices, existingIndices] = _.partition(storeSchema.indexes, index =>
+                            const [newIndices, existingIndices] = partition(storeSchema.indexes, index =>
                                 !indexMetaDictionary[getIndexIdentifier(storeSchema, index)]);
 
-                            const existingIndexColumns = _.intersection(existingIndices, columnBasedIndices);
+                            const existingIndexColumns = intersection(existingIndices, columnBasedIndices);
 
                             // find indices in the meta that do not exist in the new schema
-                            const allRemovedIndexMetas = _.filter(currentIndexMetas, meta => 
+                            const allRemovedIndexMetas = filter(currentIndexMetas, meta => 
                                 !indexIdentifierDictionary[meta.key]);
 
-                            const [removedTableIndexMetas, removedColumnIndexMetas] = _.partition(allRemovedIndexMetas, 
+                            const [removedTableIndexMetas, removedColumnIndexMetas] = partition(allRemovedIndexMetas, 
                                 meta => indexUsesSeparateTable(meta.index, this._supportsFTS3));
 
                             // find new indices which don't require backfill
-                            const newNoBackfillIndices = _.filter(newIndices, index => {
+                            const newNoBackfillIndices = filter(newIndices, index => {
                                 return !!index.doNotBackfill;
                             });
 
                             // columns requiring no backfill could be simply added to the table
-                            const newIndexColumnsNoBackfill = _.intersection(newNoBackfillIndices, columnBasedIndices);
+                            const newIndexColumnsNoBackfill = intersection(newNoBackfillIndices, columnBasedIndices);
 
                             const columnAdder = () => {
-                                const addQueries = _.map(newIndexColumnsNoBackfill, index => 
+                                const addQueries = map(newIndexColumnsNoBackfill, index => 
                                     trans.runQuery('ALTER TABLE ' + storeSchema.name + ' ADD COLUMN ' + 'nsp_i_' + index.name + ' TEXT')
                                 );
 
@@ -388,12 +387,12 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                             };
 
                             const columnExists = (tableName: string, columnName: string) => {
-                                return _.includes(tableColumns[tableName], columnName);
+                                return includes(tableColumns[tableName], columnName);
                             };
 
                             const needsFullMigration = () => {
                                 // Check all the indices in the schema
-                                return _.some(storeSchema.indexes, index => {
+                                return some(storeSchema.indexes, index => {
                                     const indexIdentifier = getIndexIdentifier(storeSchema, index);
                                     const indexMeta = indexMetaDictionary[indexIdentifier];
                                     
@@ -404,13 +403,13 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                                     }
 
                                     // If the index schemas don't match - we need to migrate
-                                    if (!_.isEqual(indexMeta.index, index)) {
+                                    if (!isEqual(indexMeta.index, index)) {
                                         return true;    
                                     }
 
                                     // Check that indicies actually exist in the right place
                                     if (indexUsesSeparateTable(index, this._supportsFTS3)) {
-                                        if (!_.includes(tableNames, indexIdentifier)) {
+                                        if (!includes(tableNames, indexIdentifier)) {
                                             return true;
                                         }
                                     } else {
@@ -424,12 +423,12 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                             };
 
                             const dropColumnIndices = () => {
-                                return _.map(indexNames[storeSchema.name], indexName =>
+                                return map(indexNames[storeSchema.name], indexName =>
                                     trans.runQuery('DROP INDEX ' + indexName));
                             };
 
                             const dropIndexTables = (tableNames: string[]) => {
-                                return _.map(tableNames, tableName => 
+                                return map(tableNames, tableName => 
                                     trans.runQuery('DROP TABLE IF EXISTS ' + storeSchema.name + '_' + tableName)
                                 );
                             };
@@ -445,16 +444,16 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
 
                             // find is there are some columns that should be, but are not indices
                             // this is to fix a mismatch between the schema in metadata and the actual table state
-                            const someIndicesMissing = _.some(columnBasedIndices, index => 
+                            const someIndicesMissing = some(columnBasedIndices, index => 
                                 columnExists(storeSchema.name, 'nsp_i_' + index.name) 
-                                    && !_.includes(indexNames[storeSchema.name], getIndexIdentifier(storeSchema, index))
+                                    && !includes(indexNames[storeSchema.name], getIndexIdentifier(storeSchema, index))
                             );
 
                             // If the table exists, check if we can to determine if a migration is needed
                             // If a full migration is needed, we have to copy all the data over and re-populate indices
                             // If a in-place migration is enough, we can just copy the data
                             // If no migration is needed, we can just add new column for new indices
-                            const tableExists = _.includes(tableNames, storeSchema.name);
+                            const tableExists = includes(tableNames, storeSchema.name);
                             const doFullMigration = tableExists && needsFullMigration();
                             const doSqlInPlaceMigration = tableExists && !doFullMigration && removedColumnIndexMetas.length > 0;
                             const adddNewColumns = tableExists && !doFullMigration && !doSqlInPlaceMigration 
@@ -517,7 +516,7 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                             if (doSqlInPlaceMigration) {
                                 const sqlInPlaceMigrator = () => {
                                     const columnsToCopy = ['nsp_pk', 'nsp_data',  
-                                        ..._.map(existingIndexColumns, index => 'nsp_i_' + index.name)
+                                        ...map(existingIndexColumns, index => 'nsp_i_' + index.name)
                                     ].join(', ');
 
                                     return trans.runQuery('INSERT INTO ' + storeSchema.name + ' (' + columnsToCopy + ')' +
@@ -556,17 +555,17 @@ export abstract class SqlProviderBase extends NoSqlProvider.DbProvider {
                         return SyncTasks.all(tableQueries);
                     });
                 });
-        }).then(_.noop);
+        }).then(noop);
     }
 }
 
 // The DbTransaction implementation for the WebSQL DbProvider.  All WebSQL accesses go through the transaction
 // object, so this class actually has several helpers for executing SQL queries, getting results from them, etc.
-export abstract class SqlTransaction implements NoSqlProvider.DbTransaction {
+export abstract class SqlTransaction implements DbTransaction {
     private _isOpen = true;
 
     constructor(
-            protected _schema: NoSqlProvider.DbSchema,
+            protected _schema: DbSchema,
             protected _verbose: boolean,
             protected _maxVariables: number,
             private _supportsFTS3: boolean) {
@@ -596,7 +595,7 @@ export abstract class SqlTransaction implements NoSqlProvider.DbTransaction {
     }
 
     internal_nonQuery(sql: string, parameters?: any[]): SyncTasks.Promise<void> {
-        return this.runQuery(sql, parameters).then<void>(_.noop);
+        return this.runQuery(sql, parameters).then<void>(noop);
     }
 
     internal_getResultsFromQuery<T>(sql: string, parameters?: any[]): SyncTasks.Promise<T[]> {
@@ -618,8 +617,8 @@ export abstract class SqlTransaction implements NoSqlProvider.DbTransaction {
             .then(rets => rets.length < 1 ? undefined : rets[0]);
     }
 
-    getStore(storeName: string): NoSqlProvider.DbStore {
-        const storeSchema = _.find(this._schema.stores, store => store.name === storeName);
+    getStore(storeName: string): DbStore {
+        const storeSchema = find(this._schema.stores, store => store.name === storeName);
         if (!storeSchema) {
             throw new Error('Store not found: ' + storeName);
         }
@@ -669,7 +668,7 @@ export interface SQLTransaction {
 export abstract class SqliteSqlTransaction extends SqlTransaction {
     private _pendingQueries: SyncTasks.Deferred<any>[] = [];
 
-    constructor(protected _trans: SQLTransaction, schema: NoSqlProvider.DbSchema, verbose: boolean, maxVariables: number,
+    constructor(protected _trans: SQLTransaction, schema: DbSchema, verbose: boolean, maxVariables: number,
             supportsFTS3: boolean) {
         super(schema, verbose, maxVariables, supportsFTS3);
     }
@@ -700,9 +699,9 @@ export abstract class SqliteSqlTransaction extends SqlTransaction {
             startTime = Date.now();
         }
 
-        const errRet = _.attempt(() => {
+        const errRet = attempt(() => {
             this._trans.executeSql(sql, parameters, (t, rs) => {
-                const index = _.indexOf(this._pendingQueries, deferred);
+                const index = indexOf(this._pendingQueries, deferred);
                 if (index !== -1) {
                     let rows = [];
                     for (let  i = 0; i < rs.rows.length; i++) {
@@ -720,7 +719,7 @@ export abstract class SqliteSqlTransaction extends SqlTransaction {
                     err = t as any;
                 }
 
-                const index = _.indexOf(this._pendingQueries, deferred);
+                const index = indexOf(this._pendingQueries, deferred);
                 if (index !== -1) {
                     this._pendingQueries.splice(index, 1);
                     deferred.reject(err);
@@ -748,17 +747,17 @@ export abstract class SqliteSqlTransaction extends SqlTransaction {
 
 // DbStore implementation for the SQL-based DbProviders.  Implements the getters/setters against the transaction object and all of the
 // glue for index/compound key support.
-class SqlStore implements NoSqlProvider.DbStore {
-    constructor(private _trans: SqlTransaction, private _schema: NoSqlProvider.StoreSchema, private _replaceUnicode: boolean,
+class SqlStore implements DbStore {
+    constructor(private _trans: SqlTransaction, private _schema: StoreSchema, private _replaceUnicode: boolean,
             private _supportsFTS3: boolean, private _verbose: boolean) {
         // Empty
     }
 
     get(key: KeyType): SyncTasks.Promise<ItemType|undefined> {
-        const joinedKey = _.attempt(() => {
-            return NoSqlProviderUtils.serializeKeyToString(key, this._schema.primaryKeyPath);
+        const joinedKey = attempt(() => {
+            return serializeKeyToString(key, this._schema.primaryKeyPath);
         });
-        if (_.isError(joinedKey)) {
+        if (isError(joinedKey)) {
             return SyncTasks.Rejected(joinedKey);
         }
 
@@ -778,10 +777,10 @@ class SqlStore implements NoSqlProvider.DbStore {
     }
 
     getMultiple(keyOrKeys: KeyType|KeyType[]): SyncTasks.Promise<ItemType[]> {
-        const joinedKeys = _.attempt(() => {
-            return NoSqlProviderUtils.formListOfSerializedKeys(keyOrKeys, this._schema.primaryKeyPath);
+        const joinedKeys = attempt(() => {
+            return formListOfSerializedKeys(keyOrKeys, this._schema.primaryKeyPath);
         });
-        if (_.isError(joinedKeys)) {
+        if (isError(joinedKeys)) {
             return SyncTasks.Rejected(joinedKeys);
         }
 
@@ -808,7 +807,7 @@ class SqlStore implements NoSqlProvider.DbStore {
     private static _unicodeFixer = new RegExp('[\u2028\u2029]', 'g');
 
     put(itemOrItems: ItemType|ItemType[]): SyncTasks.Promise<void> {
-        let items = NoSqlProviderUtils.arrayify(itemOrItems);
+        let items = arrayify(itemOrItems);
 
         if (items.length === 0) {
             return SyncTasks.Resolved<void>();
@@ -833,15 +832,15 @@ class SqlStore implements NoSqlProvider.DbStore {
         }
 
         const qmarkString = qmarks.join(',');
-        const datas = _.attempt(() => {
-            return _.map(<any[]>items, (item) => {
+        const datas = attempt(() => {
+            return map(<any[]>items, (item) => {
                 let serializedData = JSON.stringify(item);
                 // For now, until an issue with cordova-ios is fixed (https://issues.apache.org/jira/browse/CB-9435), have to replace
                 // \u2028 and 2029 with blanks because otherwise the command boundary with cordova-ios silently eats any strings with them.
                 if (this._replaceUnicode) {
                     serializedData = serializedData.replace(SqlStore._unicodeFixer, '');
                 }
-                args.push(NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._schema.primaryKeyPath), serializedData);
+                args.push(getSerializedKeyForKeypath(item, this._schema.primaryKeyPath), serializedData);
 
                 if (this._schema.indexes) {
                     for (const index of this._schema.indexes) {
@@ -851,9 +850,9 @@ class SqlStore implements NoSqlProvider.DbStore {
 
                         if (index.fullText && !this._supportsFTS3) {
                             args.push(FakeFTSJoinToken +
-                                FullTextSearchHelpers.getFullTextIndexWordsForItem(<string>index.keyPath, item).join(FakeFTSJoinToken));
+                                getFullTextIndexWordsForItem(<string>index.keyPath, item).join(FakeFTSJoinToken));
                         } else if (!index.multiEntry) {
-                            args.push(NoSqlProviderUtils.getSerializedKeyForKeypath(item, index.keyPath));
+                            args.push(getSerializedKeyForKeypath(item, index.keyPath));
                         }
                     }
                 }
@@ -861,7 +860,7 @@ class SqlStore implements NoSqlProvider.DbStore {
                 return serializedData;
             });
         });
-        if (_.isError(datas)) {
+        if (isError(datas)) {
             return SyncTasks.Rejected<void>(datas);
         }
 
@@ -870,13 +869,13 @@ class SqlStore implements NoSqlProvider.DbStore {
         const itemPageSize = Math.floor(this._trans.internal_getMaxVariables() / fields.length);
         for (let i = 0; i < items.length; i += itemPageSize) {
             const thisPageCount = Math.min(itemPageSize, items.length - i);
-            const qmarksValues = _.fill(new Array(thisPageCount), qmarkString);
+            const qmarksValues = fill(new Array(thisPageCount), qmarkString);
             queries.push(this._trans.internal_nonQuery('INSERT OR REPLACE INTO ' + this._schema.name + ' (' + fields.join(',') +
                 ') VALUES (' + qmarksValues.join('),(') + ')', args.splice(0, thisPageCount * fields.length)));
         }
 
         // Also prepare mulltiEntry and FullText indexes
-        if (_.some(this._schema.indexes, index => indexUsesSeparateTable(index, this._supportsFTS3))) {
+        if (some(this._schema.indexes, index => indexUsesSeparateTable(index, this._supportsFTS3))) {
             const keysToDeleteByIndex: { [indexIndex: number]: string[] } = {};
             const dataToInsertByIndex: { [indexIndex: number]: string[] } = {};
 
@@ -884,10 +883,10 @@ class SqlStore implements NoSqlProvider.DbStore {
             let itemIndex = -1;
             for (const item of items) {
                 itemIndex++;
-                const key = _.attempt(() => {
-                    return NoSqlProviderUtils.getSerializedKeyForKeypath(item, this._schema.primaryKeyPath)!!!;
+                const key = attempt(() => {
+                    return getSerializedKeyForKeypath(item, this._schema.primaryKeyPath)!!!;
                 });
-                if (_.isError(key)) {
+                if (isError(key)) {
                     queries.push(SyncTasks.Rejected<void>(key));
                     continue;
                 }
@@ -901,16 +900,16 @@ class SqlStore implements NoSqlProvider.DbStore {
 
                         if (index.fullText && this._supportsFTS3) {
                             // FTS3 terms go in a separate virtual table...
-                            serializedKeys = [FullTextSearchHelpers.getFullTextIndexWordsForItem(<string>index.keyPath, item).join(' ')];
+                            serializedKeys = [getFullTextIndexWordsForItem(<string>index.keyPath, item).join(' ')];
                         } else if (index.multiEntry) {
                             // Have to extract the multiple entries into the alternate table...
-                            const valsRaw = NoSqlProviderUtils.getValueForSingleKeypath(item, <string>index.keyPath);
+                            const valsRaw = getValueForSingleKeypath(item, <string>index.keyPath);
                             if (valsRaw) {
-                                const serializedKeysOrErr = _.attempt(() => {
-                                    return _.map(NoSqlProviderUtils.arrayify(valsRaw), val =>
-                                        NoSqlProviderUtils.serializeKeyToString(val, <string>index.keyPath));
+                                const serializedKeysOrErr = attempt(() => {
+                                    return map(arrayify(valsRaw), val =>
+                                        serializeKeyToString(val, <string>index.keyPath));
                                 });
-                                if (_.isError(serializedKeysOrErr)) {
+                                if (isError(serializedKeysOrErr)) {
                                     queries.push(SyncTasks.Rejected<void>(serializedKeysOrErr));
                                     continue;
                                 }
@@ -949,9 +948,9 @@ class SqlStore implements NoSqlProvider.DbStore {
 
             const deleteQueries: SyncTasks.Promise<void>[] = [];
 
-            _.each(keysToDeleteByIndex, (keysToDelete, indedIndex) => {
+            each(keysToDeleteByIndex, (keysToDelete, indedIndex) => {
                 // We know indexes are defined if we have data to insert for them
-                // _.each spits dictionary keys out as string, needs to turn into a number
+                // each spits dictionary keys out as string, needs to turn into a number
                 const index = this._schema.indexes!!![Number(indedIndex)];
                 const itemPageSize = this._trans.internal_getMaxVariables();
                 for (let i = 0; i < keysToDelete.length; i += itemPageSize) {
@@ -964,22 +963,22 @@ class SqlStore implements NoSqlProvider.DbStore {
             // Delete and insert tracking - cannot insert until delete is completed
             queries.push(SyncTasks.all(deleteQueries).then(() => {
                 const insertQueries: SyncTasks.Promise<void>[] = [];
-                _.each(dataToInsertByIndex, (data, indexIndex) => {
+                each(dataToInsertByIndex, (data, indexIndex) => {
                     // We know indexes are defined if we have data to insert for them
-                    // _.each spits dictionary keys out as string, needs to turn into a number
+                    // each spits dictionary keys out as string, needs to turn into a number
                     const index = this._schema.indexes!!![Number(indexIndex)];
                     const insertParamCount = index.includeDataInIndex ? 3 : 2;
                     const itemPageSize = Math.floor(this._trans.internal_getMaxVariables() / insertParamCount);
                     // data contains all the input parameters
                     for (let i = 0; i < (data.length / insertParamCount); i += itemPageSize) {
                         const thisPageCount = Math.min(itemPageSize, (data.length / insertParamCount) - i);
-                        const qmarksValues = _.fill(new Array(thisPageCount), generateParamPlaceholder(insertParamCount));
+                        const qmarksValues = fill(new Array(thisPageCount), generateParamPlaceholder(insertParamCount));
                         insertQueries.push(this._trans.internal_nonQuery('INSERT INTO ' +
                             this._schema.name + '_' + index.name + ' (nsp_key, nsp_refpk' + (index.includeDataInIndex ? ', nsp_data' : '') +
                             ') VALUES ' + '(' + qmarksValues.join('),(') + ')', data.splice(0, thisPageCount * insertParamCount)));
                     }
                 });
-                return SyncTasks.all(insertQueries).then(_.noop);
+                return SyncTasks.all(insertQueries).then(noop);
             }));
             
         }
@@ -990,14 +989,14 @@ class SqlStore implements NoSqlProvider.DbStore {
                 console.log('SqlStore (' + this._schema.name + ') put: (' + (Date.now() - startTime) + 'ms): Count: ' + items.length);
             });
         }
-        return promise.then(_.noop);
+        return promise.then(noop);
     }
 
     remove(keyOrKeys: KeyType|KeyType[]): SyncTasks.Promise<void> {
-        const joinedKeys = _.attempt(() => {
-            return NoSqlProviderUtils.formListOfSerializedKeys(keyOrKeys, this._schema.primaryKeyPath);
+        const joinedKeys = attempt(() => {
+            return formListOfSerializedKeys(keyOrKeys, this._schema.primaryKeyPath);
         });
-        if (_.isError(joinedKeys)) {
+        if (isError(joinedKeys)) {
             return SyncTasks.Rejected<void>(joinedKeys);
         }
 
@@ -1032,7 +1031,7 @@ class SqlStore implements NoSqlProvider.DbStore {
             }
         });
 
-        const queries = _.map(arrayOfParams, params => {
+        const queries = map(arrayOfParams, params => {
             let queries: SyncTasks.Promise<void>[] = [];
 
             if (params.length === 0) {
@@ -1054,10 +1053,10 @@ class SqlStore implements NoSqlProvider.DbStore {
             queries.push(this._trans.internal_nonQuery('DELETE FROM ' + this._schema.name +
                 ' WHERE nsp_pk IN (' + placeholder + ')', params));
 
-            return SyncTasks.all(queries).then(_.noop);
+            return SyncTasks.all(queries).then(noop);
         });
 
-        let promise = SyncTasks.all(queries).then(_.noop);
+        let promise = SyncTasks.all(queries).then(noop);
         if (this._verbose) {
             promise = promise.finally(() => {
                 console.log('SqlStore (' + this._schema.name + ') remove: (' + (Date.now() - startTime) + 'ms): Count: ' +
@@ -1067,8 +1066,8 @@ class SqlStore implements NoSqlProvider.DbStore {
         return promise;
     }
 
-    openIndex(indexName: string): NoSqlProvider.DbIndex {
-        const indexSchema = _.find(this._schema.indexes, index => index.name === indexName);
+    openIndex(indexName: string): DbIndex {
+        const indexSchema = find(this._schema.indexes, index => index.name === indexName);
         if (!indexSchema) {
             throw new Error('Index not found: ' + indexName);
         }
@@ -1076,31 +1075,31 @@ class SqlStore implements NoSqlProvider.DbStore {
         return new SqlStoreIndex(this._trans, this._schema, indexSchema, this._supportsFTS3, this._verbose);
     }
 
-    openPrimaryKey(): NoSqlProvider.DbIndex {
+    openPrimaryKey(): DbIndex {
         return new SqlStoreIndex(this._trans, this._schema, undefined, this._supportsFTS3, this._verbose);
     }
 
     clearAllData(): SyncTasks.Promise<void> {
-        let indexes = _.filter(this._schema.indexes, index => indexUsesSeparateTable(index, this._supportsFTS3));
-        let queries = _.map(indexes, index =>
+        let indexes = filter(this._schema.indexes, index => indexUsesSeparateTable(index, this._supportsFTS3));
+        let queries = map(indexes, index =>
             this._trans.internal_nonQuery('DELETE FROM ' + this._schema.name + '_' + index.name));
 
         queries.push(this._trans.internal_nonQuery('DELETE FROM ' + this._schema.name));
 
-        return SyncTasks.all(queries).then(_.noop);
+        return SyncTasks.all(queries).then(noop);
     }
 }
 
 // DbIndex implementation for SQL-based DbProviders.  Wraps all of the nasty compound key logic and general index traversal logic into
 // the appropriate SQL queries.
-class SqlStoreIndex implements NoSqlProvider.DbIndex {
+class SqlStoreIndex implements DbIndex {
     private _queryColumn: string;
     private _tableName: string;
     private _rawTableName: string;
     private _indexTableName: string;
     private _keyPath: string | string[];
 
-    constructor(protected _trans: SqlTransaction, storeSchema: NoSqlProvider.StoreSchema, indexSchema: NoSqlProvider.IndexSchema|undefined,
+    constructor(protected _trans: SqlTransaction, storeSchema: StoreSchema, indexSchema: IndexSchema|undefined,
             private _supportsFTS3: boolean, private _verbose: boolean) {
         if (!indexSchema) {
             // Going against the PK of the store
@@ -1133,11 +1132,11 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
         }
     }
 
-    private _handleQuery(sql: string, args?: any[], reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number,
+    private _handleQuery(sql: string, args?: any[], reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number,
             offset?: number): SyncTasks.Promise<ItemType[]> {
         // Check if we must do some sort of ordering
-        if (reverseOrSortOrder !== NoSqlProvider.QuerySortOrder.None) {
-            const reverse = reverseOrSortOrder === true || reverseOrSortOrder === NoSqlProvider.QuerySortOrder.Reverse;
+        if (reverseOrSortOrder !== QuerySortOrder.None) {
+            const reverse = reverseOrSortOrder === true || reverseOrSortOrder === QuerySortOrder.Reverse;
             sql += ' ORDER BY ' + this._queryColumn + (reverse ? ' DESC' : ' ASC');
         }
 
@@ -1158,7 +1157,7 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
         return this._trans.internal_getResultsFromQuery(sql, args);
     }
 
-    getAll(reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
+    getAll(reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
         let startTime: number;
         if (this._verbose) {
             startTime = Date.now();
@@ -1174,12 +1173,12 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
         return promise;
     }
 
-    getOnly(key: KeyType, reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number)
+    getOnly(key: KeyType, reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number)
             : SyncTasks.Promise<ItemType[]> {
-        const joinedKey = _.attempt(() => {
-            return NoSqlProviderUtils.serializeKeyToString(key, this._keyPath);
+        const joinedKey = attempt(() => {
+            return serializeKeyToString(key, this._keyPath);
         });
-        if (_.isError(joinedKey)) {
+        if (isError(joinedKey)) {
             return SyncTasks.Rejected(joinedKey);
         }
 
@@ -1200,10 +1199,10 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
     }
 
     getRange(keyLowRange: KeyType, keyHighRange: KeyType, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
-            reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
+            reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ItemType[]> {
         let checks: string;
         let args: string[];
-        const err = _.attempt(() => {
+        const err = attempt(() => {
             const ret = this._getRangeChecks(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
             checks = ret.checks;
             args = ret.args;
@@ -1235,11 +1234,11 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
         let args: string[] = [];
         if (keyLowRange !== null && keyLowRange !== undefined) {
             checks.push(this._queryColumn + (lowRangeExclusive ? ' > ' : ' >= ') + '?');
-            args.push(NoSqlProviderUtils.serializeKeyToString(keyLowRange, this._keyPath));
+            args.push(serializeKeyToString(keyLowRange, this._keyPath));
         }
         if (keyHighRange !== null && keyHighRange !== undefined) {
             checks.push(this._queryColumn + (highRangeExclusive ? ' < ' : ' <= ') + '?');
-            args.push(NoSqlProviderUtils.serializeKeyToString(keyHighRange, this._keyPath));
+            args.push(serializeKeyToString(keyHighRange, this._keyPath));
         }
         return { checks: checks.join(' AND '), args };
     }
@@ -1261,10 +1260,10 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
     }
 
     countOnly(key: KeyType): SyncTasks.Promise<number> {
-        const joinedKey = _.attempt(() => {
-            return NoSqlProviderUtils.serializeKeyToString(key, this._keyPath);
+        const joinedKey = attempt(() => {
+            return serializeKeyToString(key, this._keyPath);
         });
-        if (_.isError(joinedKey)) {
+        if (isError(joinedKey)) {
             return SyncTasks.Rejected(joinedKey);
         }
 
@@ -1288,7 +1287,7 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
             : SyncTasks.Promise<number> {
         let checks: string;
         let args: string[];
-        const err = _.attempt(() => {
+        const err = attempt(() => {
             const ret = this._getRangeChecks(keyLowRange, keyHighRange, lowRangeExclusive, highRangeExclusive);
             checks = ret.checks;
             args = ret.args;
@@ -1313,46 +1312,46 @@ class SqlStoreIndex implements NoSqlProvider.DbIndex {
         return promise;
     }
 
-    fullTextSearch(searchPhrase: string, resolution: NoSqlProvider.FullTextTermResolution = NoSqlProvider.FullTextTermResolution.And,
+    fullTextSearch(searchPhrase: string, resolution: FullTextTermResolution = FullTextTermResolution.And,
             limit?: number): SyncTasks.Promise<ItemType[]> {
         let startTime: number;
         if (this._verbose) {
             startTime = Date.now();
         }
 
-        const terms = FullTextSearchHelpers.breakAndNormalizeSearchPhrase(searchPhrase);
+        const terms = breakAndNormalizeSearchPhrase(searchPhrase);
         if (terms.length === 0) {
             return SyncTasks.Resolved([]);
         }
 
         let promise: SyncTasks.Promise<ItemType[]>;
         if (this._supportsFTS3) {
-            if (resolution === NoSqlProvider.FullTextTermResolution.And) {
+            if (resolution === FullTextTermResolution.And) {
                 promise = this._handleQuery('SELECT nsp_data FROM ' + this._tableName + ' WHERE ' + this._queryColumn + ' MATCH ?',
-                    [_.map(terms, term => term + '*').join(' ')], false, limit);
-            } else if (resolution === NoSqlProvider.FullTextTermResolution.Or) {
+                    [map(terms, term => term + '*').join(' ')], false, limit);
+            } else if (resolution === FullTextTermResolution.Or) {
                 // SQLite FTS3 doesn't support OR queries so we have to hack it...
-                const baseQueries = _.map(terms, term => 'SELECT * FROM ' + this._indexTableName + ' WHERE nsp_key MATCH ?');
+                const baseQueries = map(terms, term => 'SELECT * FROM ' + this._indexTableName + ' WHERE nsp_key MATCH ?');
                 const joinedQuery = 'SELECT * FROM (SELECT DISTINCT * FROM (' + baseQueries.join(' UNION ALL ') + ')) mi LEFT JOIN ' +
                     this._rawTableName + ' t ON mi.nsp_refpk = t.nsp_pk';
-                const args = _.map(terms, term => term + '*');
+                const args = map(terms, term => term + '*');
                 promise = this._handleQuery(joinedQuery, args, false, limit);
             } else {
                 return SyncTasks.Rejected('fullTextSearch called with invalid term resolution mode');
             }
         } else {
             let joinTerm: string;
-            if (resolution === NoSqlProvider.FullTextTermResolution.And) {
+            if (resolution === FullTextTermResolution.And) {
                 joinTerm = ' AND ';
-            } else if (resolution === NoSqlProvider.FullTextTermResolution.Or) {
+            } else if (resolution === FullTextTermResolution.Or) {
                 joinTerm = ' OR ';
             } else {
                 return SyncTasks.Rejected('fullTextSearch called with invalid term resolution mode');
             }
 
             promise = this._handleQuery('SELECT nsp_data FROM ' + this._tableName + ' WHERE ' +
-                _.map(terms, term => this._queryColumn + ' LIKE ?').join(joinTerm),
-                _.map(terms, term => '%' + FakeFTSJoinToken + term + '%'));
+                map(terms, term => this._queryColumn + ' LIKE ?').join(joinTerm),
+                map(terms, term => '%' + FakeFTSJoinToken + term + '%'));
         }
         if (this._verbose) {
             promise = promise.finally(() => {

--- a/src/StoreHelpers.ts
+++ b/src/StoreHelpers.ts
@@ -6,10 +6,9 @@
  * Reusable helper classes for clients of NoSqlProvider to build more type-safe stores/indexes.
  */
 
-import SyncTasks = require('synctasks');
+import * as SyncTasks  from 'synctasks';
 
-import NoSqlProvider = require('./NoSqlProvider');
-import { ItemType, KeyType } from './NoSqlProvider';
+import { DbIndex, QuerySortOrder, FullTextTermResolution, ItemType, KeyType, DbStore } from './NoSqlProvider';
 
 export var ErrorCatcher: ((err: any) => SyncTasks.Promise<any>)|undefined = undefined;
 
@@ -22,23 +21,23 @@ export type DBStore<Name extends string, ObjectType, KeyFormat> = string & { nam
 export type DBIndex<Store extends DBStore<string, any, any>, IndexKeyFormat> = string & { store?: Store, indexKeyFormat?: IndexKeyFormat };
 
 export class SimpleTransactionIndexHelper<ObjectType extends ItemType, IndexKeyFormat extends KeyType> {
-    constructor(protected _index: NoSqlProvider.DbIndex) {
+    constructor(protected _index: DbIndex) {
         // Nothing to see here
     }
 
-    getAll(reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
+    getAll(reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
         let promise = this._index.getAll(reverseOrSortOrder, limit, offset) as SyncTasks.Promise<ObjectType[]>;
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
     }
 
-    getOnly(key: IndexKeyFormat, reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number)
+    getOnly(key: IndexKeyFormat, reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number)
             : SyncTasks.Promise<ObjectType[]> {
         let promise = this._index.getOnly(key, reverseOrSortOrder, limit, offset) as SyncTasks.Promise<ObjectType[]>;
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
     }
 
     getRange(keyLowRange: IndexKeyFormat, keyHighRange: IndexKeyFormat, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
-        reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
+        reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
         let promise = this._index.getRange(keyLowRange, keyHighRange, lowRangeExclusive,
             highRangeExclusive, reverseOrSortOrder, limit, offset) as SyncTasks.Promise<ObjectType[]>;
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
@@ -60,7 +59,7 @@ export class SimpleTransactionIndexHelper<ObjectType extends ItemType, IndexKeyF
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
     }
 
-    fullTextSearch(searchPhrase: string, resolution?: NoSqlProvider.FullTextTermResolution,
+    fullTextSearch(searchPhrase: string, resolution?: FullTextTermResolution,
             limit?: number): SyncTasks.Promise<ObjectType[]> {
         // Sanitize input by removing parens, the plugin on RN explodes
         let promise = this._index.fullTextSearch(searchPhrase.replace(FullTextSanitizeRegex, ''),
@@ -70,7 +69,7 @@ export class SimpleTransactionIndexHelper<ObjectType extends ItemType, IndexKeyF
 }
 
 export class SimpleTransactionStoreHelper<StoreName extends string, ObjectType extends ItemType, KeyFormat extends KeyType> {
-    constructor(protected _store: NoSqlProvider.DbStore, storeName /* Force type-checking */: DBStore<StoreName, ObjectType, KeyFormat>) {
+    constructor(protected _store: DbStore, storeName /* Force type-checking */: DBStore<StoreName, ObjectType, KeyFormat>) {
         // Nothing to see here
     }
 
@@ -79,19 +78,19 @@ export class SimpleTransactionStoreHelper<StoreName extends string, ObjectType e
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
     }
 
-    getAll(sortOrder?: NoSqlProvider.QuerySortOrder): SyncTasks.Promise<ObjectType[]> {
+    getAll(sortOrder?: QuerySortOrder): SyncTasks.Promise<ObjectType[]> {
         let promise = this._store.openPrimaryKey().getAll(sortOrder) as SyncTasks.Promise<ObjectType[]>;
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
     }
 
-    getOnly(key: KeyFormat, reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number)
+    getOnly(key: KeyFormat, reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number)
             : SyncTasks.Promise<ObjectType[]> {
         let promise = this._store.openPrimaryKey().getOnly(key, reverseOrSortOrder, limit, offset) as SyncTasks.Promise<ObjectType[]>;
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;
     }
 
     getRange(keyLowRange: KeyFormat, keyHighRange: KeyFormat, lowRangeExclusive?: boolean, highRangeExclusive?: boolean,
-            reverseOrSortOrder?: boolean | NoSqlProvider.QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
+            reverseOrSortOrder?: boolean | QuerySortOrder, limit?: number, offset?: number): SyncTasks.Promise<ObjectType[]> {
         let promise = this._store.openPrimaryKey().getRange(keyLowRange, keyHighRange,
             lowRangeExclusive, highRangeExclusive, reverseOrSortOrder, limit, offset) as SyncTasks.Promise<ObjectType[]>;
         return ErrorCatcher ? promise.catch(ErrorCatcher) : promise;

--- a/src/WebSqlProvider.ts
+++ b/src/WebSqlProvider.ts
@@ -6,35 +6,35 @@
  * NoSqlProvider provider setup for WebSql, a browser storage backing.
  */
 
-import _ = require('lodash');
-import SyncTasks = require('synctasks');
+import { noop } from 'lodash';
+import * as SyncTasks from 'synctasks';
 
-import NoSqlProvider = require('./NoSqlProvider');
-import SqlProviderBase = require('./SqlProviderBase');
+import { DbSchema } from './NoSqlProvider';
+import { SQLDatabase, SqlProviderBase, SqlTransaction, SqliteSqlTransaction, SQLError, SQLTransaction } from './SqlProviderBase';
 
 // Extending interfaces that should be in lib.d.ts but aren't for some reason.
 export interface SQLDatabaseCallback {
-    (database: SqlProviderBase.SQLDatabase): void;
+    (database: SQLDatabase): void;
 }
 
 declare global {
     interface Window {
         openDatabase(database_name: string, database_version: string, database_displayname: string,
-            database_size?: number, creationCallback?: SQLDatabaseCallback): SqlProviderBase.SQLDatabase;
+            database_size?: number, creationCallback?: SQLDatabaseCallback): SQLDatabase;
     }
 }
 
 // The DbProvider implementation for WebSQL.  This provider does a bunch of awkward stuff to pretend that a relational SQL store
 // is actually a NoSQL store.  We store the raw object as a JSON.encoded string in the nsp_data column, and have an nsp_pk column
 // for the primary keypath value, then nsp_i_[index name] columns for each of the indexes.
-export class WebSqlProvider extends SqlProviderBase.SqlProviderBase {
-    private _db: SqlProviderBase.SQLDatabase|undefined;
+export class WebSqlProvider extends SqlProviderBase {
+    private _db: SQLDatabase|undefined;
 
     constructor(supportsFTS3 = true) {
         super(supportsFTS3);
     }
 
-    open(dbName: string, schema: NoSqlProvider.DbSchema, wipeIfExists: boolean, verbose: boolean): SyncTasks.Promise<void> {
+    open(dbName: string, schema: DbSchema, wipeIfExists: boolean, verbose: boolean): SyncTasks.Promise<void> {
         super.open(dbName, schema, wipeIfExists, verbose);
 
         if (!window.openDatabase) {
@@ -114,21 +114,21 @@ export class WebSqlProvider extends SqlProviderBase.SqlProviderBase {
         return SyncTasks.Rejected<void>('No support for deleting');
     }
 
-    openTransaction(storeNames: string[], writeNeeded: boolean): SyncTasks.Promise<SqlProviderBase.SqlTransaction> {
+    openTransaction(storeNames: string[], writeNeeded: boolean): SyncTasks.Promise<SqlTransaction> {
         if (!this._db) {
             return SyncTasks.Rejected('Database closed');
         }
 
-        const deferred = SyncTasks.Defer<SqlProviderBase.SqlTransaction>();
+        const deferred = SyncTasks.Defer<SqlTransaction>();
 
-        let ourTrans: SqlProviderBase.SqliteSqlTransaction|undefined;
+        let ourTrans: SqliteSqlTransaction|undefined;
         let finishDefer: SyncTasks.Deferred<void>|undefined = SyncTasks.Defer<void>();
         (writeNeeded ? this._db.transaction : this._db.readTransaction).call(this._db,
-            (trans: SqlProviderBase.SQLTransaction) => {
+            (trans: SQLTransaction) => {
                 ourTrans = new WebSqlTransaction(trans, finishDefer!!!.promise(), this._schema!!!, this._verbose!!!, 999,
                     this._supportsFTS3);
                 deferred.resolve(ourTrans);
-            }, (err: SqlProviderBase.SQLError) => {
+            }, (err: SQLError) => {
                 if (ourTrans) {
                     // Got an error from inside the transaction.  Error out all pending queries on the 
                     // transaction since they won't exit out gracefully for whatever reason.
@@ -153,10 +153,10 @@ export class WebSqlProvider extends SqlProviderBase.SqlProviderBase {
     }
 }
 
-class WebSqlTransaction extends SqlProviderBase.SqliteSqlTransaction {
-    constructor(protected trans: SqlProviderBase.SQLTransaction,
+class WebSqlTransaction extends SqliteSqlTransaction {
+    constructor(protected trans: SQLTransaction,
                 private _completionPromise: SyncTasks.Promise<void>, 
-                schema: NoSqlProvider.DbSchema,
+                schema: DbSchema,
                 verbose: boolean,
                 maxVariables: number,
                 supportsFTS3: boolean) {
@@ -170,7 +170,7 @@ class WebSqlTransaction extends SqlProviderBase.SqliteSqlTransaction {
     abort(): void {
         // The only way to rollback a websql transaction is by forcing an error (which rolls back the trans):
         // http://stackoverflow.com/questions/16225320/websql-dont-rollback
-        this.runQuery('ERROR ME TO DEATH').always(_.noop);
+        this.runQuery('ERROR ME TO DEATH').always(noop);
     }
 
     getErrorHandlerReturnValue(): boolean {

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -2275,21 +2275,21 @@ describe('NoSqlProvider', function () {
                                                 primaryKeyPath: 'id'
                                             }
                                         ]
-                                    }, false)
-                                        .then(prov => {
-                                            return prov.openTransaction(undefined, false).then(trans => {
-                                                return (trans as SqlTransaction).runQuery('SELECT name, value from metadata').then(fullMeta => {
-                                                    each(fullMeta, (meta: any) => {
-                                                        let metaObj = JSON.parse(meta.value);
-                                                        if (metaObj.storeName === 'test' && !!metaObj.index && metaObj.index.name === 'ind1') {
-                                                            assert.fail('Removed index should not exist in the meta!');
-                                                        }
-                                                    });
-                                                });
-                                            }).then(() => {
-                                                return prov.close();
+                                    }, false);
+                                })
+                                .then(prov => {
+                                    return prov.openTransaction(undefined, false).then(trans => {
+                                        return (trans as SqlTransaction).runQuery('SELECT name, value from metadata').then(fullMeta => {
+                                            each(fullMeta, (meta: any) => {
+                                                let metaObj = JSON.parse(meta.value);
+                                                if (metaObj.storeName === 'test' && !!metaObj.index && metaObj.index.name === 'ind1') {
+                                                    assert.fail('Removed index should not exist in the meta!');
+                                                }
                                             });
                                         });
+                                    }).then(() => {
+                                        return prov.close();
+                                    });
                                 });
                         });
 


### PR DESCRIPTION
This commit is to standardize all imports in nosqlprovider to es6, and also set sideEffects as false. 
The sideEffects false helps with tree-shaking in webpack and other libraries. 

I've also fixed up all the TSLint errors that were present in some of the test files.