### PR TITLE
Adding in es6 promise polyfills to prepare for migration from syncTasks-es6 promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@types/lodash": "^4.14.149",
     "@types/sqlite3": "^3.1.6",
+    "core-js": "^3.6.5",
     "lodash": "^4.17.15",
     "regexp-i18n": "^1.3.2",
     "synctasks": "^0.3.3"

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -8,7 +8,7 @@
 
 import { each, some, find, includes, isObject, attempt, isError, map, filter, compact, clone, isArray, noop } from 'lodash';
 import SyncTasks = require('synctasks');
-
+import { getWindow } from './get-window';
 import { DbIndexFTSFromRangeQueries, getFullTextIndexWordsForItem } from './FullTextSearchHelpers';
 import {
     DbProvider, DbSchema, DbStore, DbTransaction, StoreSchema, DbIndex,
@@ -73,7 +73,7 @@ export class IndexedDbProvider extends DbProvider {
             this._dbFactory = explicitDbFactory;
             this._fakeComplicatedKeys = !explicitDbFactorySupportsCompoundKeys;
         } else {
-            const win = this.getWindow();
+            const win = getWindow();
             this._dbFactory = win._indexedDB || win.indexedDB || win.mozIndexedDB || win.webkitIndexedDB || win.msIndexedDB;
 
             if (typeof explicitDbFactorySupportsCompoundKeys !== 'undefined') {
@@ -84,20 +84,6 @@ export class IndexedDbProvider extends DbProvider {
                 this._fakeComplicatedKeys = isIE();
             }
         }
-    }
-
-    /**
-     * Gets global window object - whether operating in worker or UI thread context.
-     * Adapted from: https://stackoverflow.com/questions/7931182/reliably-detect-if-the-script-is-executing-in-a-web-worker
-     */
-    getWindow() {
-        if (typeof window === 'object' && window.document) {
-            return window;
-        } else if (self && self.document === undefined) {
-            return self;
-        }
-
-        throw new Error('Undefined context');
     }
 
     static WrapRequest<T>(req: IDBRequest): SyncTasks.Promise<T> {

--- a/src/NoSqlProvider.ts
+++ b/src/NoSqlProvider.ts
@@ -9,7 +9,7 @@
  * of the helper interfaces, while the specific database providers should
  * be required piecemeal.
  */
-
+import "./Promise.extensions"; // See the file for why it is being imported like this.
 import { noop, attempt, isError } from 'lodash';
 import * as SyncTasks from 'synctasks';
 

--- a/src/Promise.d.ts
+++ b/src/Promise.d.ts
@@ -1,0 +1,3 @@
+declare interface Promise<T> {
+    always: <U>(func: (value: T | any) => U | PromiseLike<U>) => Promise<U>;
+}

--- a/src/Promise.extensions.ts
+++ b/src/Promise.extensions.ts
@@ -1,0 +1,77 @@
+import 'core-js/features/promise';
+import 'core-js/features/promise/finally';
+import { getWindow } from './get-window';
+
+/**
+ * Below is a polyfill for Promise.always
+ */
+if (!Promise.prototype.always) {
+    Promise.prototype.always = function (onResolveOrReject) {
+        return this.then(onResolveOrReject,
+            function (reason: any) {
+                onResolveOrReject(reason);
+                throw reason;
+            });
+    };
+}
+
+export interface PromiseConfig {
+    // If we catch exceptions in success/fail blocks, it silently falls back to the fail case of the outer promise.
+    // If this is global variable is true, it will also spit out a console.error with the exception for debugging.
+    exceptionsToConsole: boolean,
+
+    // Whether or not to actually attempt to catch exceptions with try/catch blocks inside the resolution cases.
+    // Disable this for debugging when you'd rather the debugger caught the exception synchronously rather than
+    // digging through a stack trace.
+    catchExceptions: boolean,
+
+    // Regardless of whether an exception is caught or not, this will always execute.
+    exceptionHandler: ((ex: Error) => void) | undefined,
+
+    // If an ErrorFunc is not added to the task (then, catch, always) before the task rejects or synchonously
+    // after that, then this function is called with the error. Default throws the error.
+    unhandledErrorHandler: (err: any) => void,
+}
+
+
+let boundRejectionHandledListener: (e: PromiseRejectionEvent) => void;
+let boundUnhandledRejectionListener: (e: PromiseRejectionEvent) => void;
+
+/**
+ * This function provides a way to override the default handling behavior for ES6 promises
+ * @param config various configuration options for this.
+ */
+export function registerPromiseGlobalHandlers(config: PromiseConfig) {
+    boundRejectionHandledListener = (e: PromiseRejectionEvent) => {
+        if (config.exceptionsToConsole) {
+            console.error('handled', e.reason, e.promise)
+        }
+
+        if (config.exceptionHandler) {
+            config.exceptionHandler(e.reason);
+        }
+    };
+    boundUnhandledRejectionListener = (e: PromiseRejectionEvent) => {
+        if (config.exceptionsToConsole) {
+            console.error('unhandled', e.reason, e.promise)
+        }
+
+        if (config.catchExceptions) {
+            e.preventDefault();
+        }
+        config.unhandledErrorHandler(e.reason);
+    };
+    getWindow().addEventListener('rejectionhandled', boundRejectionHandledListener);
+
+    getWindow().addEventListener('unhandledrejection', boundUnhandledRejectionListener);
+}
+
+/**
+ * This function provides a way to unregister global listeners
+ * @param config various configuration options for this.
+ */
+export function unRegisterPromiseGlobalHandlers() {
+    getWindow().removeEventListener('rejectionhandled', boundRejectionHandledListener);
+
+    getWindow().removeEventListener('unhandledrejection', boundUnhandledRejectionListener);
+}

--- a/src/Promise.extensions.ts
+++ b/src/Promise.extensions.ts
@@ -1,3 +1,25 @@
+/**
+ * This file contains a series of promise polyfills that help with making promises 
+ * work on legacy platforms see https://caniuse.com/promises for a full list of 
+ * browsers where this can be used. 
+ * 
+ * NOTE: Promise.finally is added to the ES standard but is only available on more
+ * recent versions https://caniuse.com/mdn-javascript_builtins_promise_finally
+ * 
+ * The fila lso adds support for Promise.always (NOT ES compliant). The difference between
+ * finally and always is, always will always rethrow the exception thrown in the catch(). 
+ * 
+ * How to import this file: 
+ * As this file contains polyfills and added type definitions you would need to import it with side-effects
+ * import "./Promise.extensions" 
+ * not doing so will prevent the polyfills from being imported.
+ * 
+ * Additionally, make sure this file is imported as part of the index.ts (entry-point) for your bundle/chunk
+ * to make sure all Promise prototypes are correctly patched.
+ * 
+ * NOTE: You do not need to do anything to import this file when importing NoSQLProvider... this file is 
+ * automatically included for NoSQLProvider as part of NoSQLProvider.ts which is the main entry-point for this package
+ */
 import 'core-js/features/promise';
 import 'core-js/features/promise/finally';
 import { getWindow } from './get-window';
@@ -67,7 +89,7 @@ export function registerPromiseGlobalHandlers(config: PromiseConfig) {
 }
 
 /**
- * This function provides a way to unregister global listeners
+ * This function provides a way to unregister global listeners for promises.
  * @param config various configuration options for this.
  */
 export function unRegisterPromiseGlobalHandlers() {

--- a/src/defer.ts
+++ b/src/defer.ts
@@ -1,0 +1,16 @@
+export interface IDeferred<T> {
+    promise: Promise<T>;
+    resolve<T>(value: T | PromiseLike<T>): void;
+    resolve(): void;
+    reject(reason: unknown): void;
+}
+
+export function defer<T>(): IDeferred<T> {
+    const deferred: Partial<IDeferred<T>> = {};
+    // eslint-disable-next-line msteams/promise-must-complete
+    deferred.promise = new Promise<T>((resolve, reject) => {
+        deferred.resolve = resolve;
+        deferred.reject = reject;
+    });
+    return deferred as IDeferred<T>;
+}

--- a/src/get-window.ts
+++ b/src/get-window.ts
@@ -1,0 +1,13 @@
+/**
+     * Gets global window object - whether operating in worker or UI thread context.
+     * Adapted from: https://stackoverflow.com/questions/7931182/reliably-detect-if-the-script-is-executing-in-a-web-worker
+     */
+export function getWindow() {
+    if (typeof window === 'object' && window.document) {
+        return window;
+    } else if (self && self.document === undefined) {
+        return self;
+    }
+
+    throw new Error('Undefined context');
+}

--- a/src/tests/NoSqlProviderTests.ts
+++ b/src/tests/NoSqlProviderTests.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
 import * as PromiseExtensions from '../Promise.extensions';
+import * as assert from 'assert';
 import { find, each, times, values, keys, some, uniqueId } from 'lodash';
 import * as sinon from 'sinon';
 import * as SyncTasks from 'synctasks';

--- a/yarn.lock
+++ b/yarn.lock
@@ -815,6 +815,11 @@ copy-descriptor@^0.1.0:
   resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js@^3.6.5:
+  version "3.6.5"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha1-c5XcJzrzf7LlDpvT2f6EEoUjHRo=
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
In order to support some legacy browsers: 
1. Adding core-js es6 polyfills. 
2. Adding in core-js polyfill for es6.finally
3. Adding in custom polyfill for es6.always
4. Adding in an equivalent of SyncTasks.config to globally configure exception handling. NOTE: It doesn't seem feasible to port over .trace(), for 2 reasons
     a. This would mean monkey patching all the promise apis. This ends up de-optimizing the code in nodejs. 
     b. Chromium shows the full stack trace for promises as is, so it doesn't make much sense. 
5. Adding in a defer() method to return Q-style Deferred() objects. 
6. Adding UTs for all of the above. 

In subsequent PRs, I'll try move over the existing files a couple at a time to es6.
