### PR TITLE
Perf: Avoid creating unnecessary timers on read.

### DIFF
--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -96,6 +96,7 @@ class InMemoryTransaction implements DbTransaction {
         this._transactionCallback = () => {
             this._commitTransaction();
             this._lockHelper.transactionComplete(this._transToken);
+            this._transactionCallback = undefined;
         };
         // Close the transaction on the next tick.  By definition, anything is completed synchronously here, so after an event tick
         // goes by, there can't have been anything pending.   

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -43,8 +43,8 @@ function abortAsyncCallback(callback: () => void): void {
 
 function resolveAsyncCallbacks(): void {
     const savedCallbacks = asyncCallbacks;
-    asyncCallbacks = new Set()
-    savedCallbacks.forEach((item) =>item());
+    asyncCallbacks = new Set();
+    savedCallbacks.forEach((item) => item());
 }
 
 // Very simple in-memory dbprovider for handling IE inprivate windows (and unit tests, maybe?)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/942002/96534435-8eee7380-1244-11eb-9d47-f0660fb0cecd.png)
The above is a trace where a lot of items are being read on startup of the inMemory store, this ended up creating a lot of transactions on startup, each of which installed and executed the transaction timer referenced in this PR. 

This PR removes the creation of a timer on non-write scenarios (where even if the transaction was abort'd there would be no harm).